### PR TITLE
Periodic Events

### DIFF
--- a/example-cap-server/package.json
+++ b/example-cap-server/package.json
@@ -24,7 +24,8 @@
     "eventQueue": {
       "plugin": true,
       "configFilePath": "./srv/eventConfig.yml",
-      "parallelTenantProcessing": 2
+      "parallelTenantProcessing": 2,
+      "runInterval": 30000
     },
     "requires": {
       "multitenancy": true,

--- a/example-cap-server/srv/EventQueueHealthCheckDb.js
+++ b/example-cap-server/srv/EventQueueHealthCheckDb.js
@@ -9,7 +9,10 @@ class EventQueueMail extends eventQueue.EventQueueProcessorBase {
 
   // eslint-disable-next-line no-unused-vars
   async processEvent(processContext, key, queueEntries, payload) {
-    this.logger.info("doing db health check...");
+    this.logger.info("doing db health check...", {
+      id: queueEntries[0].ID,
+      now: new Date().toISOString(),
+    });
   }
 }
 

--- a/example-cap-server/srv/EventQueueHealthCheckDb.js
+++ b/example-cap-server/srv/EventQueueHealthCheckDb.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const eventQueue = require("@cap-js-community/event-queue");
+
+class EventQueueMail extends eventQueue.EventQueueProcessorBase {
+  constructor(context, eventType, eventSubType, config) {
+    super(context, eventType, eventSubType, config);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  async processEvent(processContext, key, queueEntries, payload) {
+    this.logger.info("doing db health check...");
+  }
+}
+
+module.exports = EventQueueMail;

--- a/example-cap-server/srv/eventConfig.yml
+++ b/example-cap-server/srv/eventConfig.yml
@@ -25,4 +25,4 @@ periodicEvents:
     impl: ./srv/EventQueueHealthCheckDb
     load: 40
     transactionMode: alwaysRollback
-    interval: 20
+    interval: 10

--- a/example-cap-server/srv/eventConfig.yml
+++ b/example-cap-server/srv/eventConfig.yml
@@ -25,4 +25,4 @@ periodicEvents:
     impl: ./srv/EventQueueHealthCheckDb
     load: 40
     transactionMode: alwaysRollback
-    interval: 10
+    interval: 20

--- a/example-cap-server/srv/eventConfig.yml
+++ b/example-cap-server/srv/eventConfig.yml
@@ -18,3 +18,11 @@ events:
     load: 40
     parallelEventProcessing: 2
     checkForNextChunk: true
+
+periodicEvents:
+  - type: HealthCheck
+    subType: DB
+    impl: ./srv/EventQueueHealthCheckDb
+    load: 40
+    transactionMode: alwaysRollback
+    interval: 10

--- a/example-cap-server/srv/server.js
+++ b/example-cap-server/srv/server.js
@@ -21,6 +21,13 @@ async function subscribeTenants() {
     await ds.subscribe(tenant);
   }
 
+  setTimeout(() => {
+    LOGGER.info("onboarding another tenant...");
+    ds.subscribe("t3").then(() => {
+      LOGGER.info("done...");
+    });
+  }, 15 * 1000);
+
   LOGGER.info("Setup of tenants finished - You can start testing now!");
 }
 

--- a/src/EventQueueError.js
+++ b/src/EventQueueError.js
@@ -12,6 +12,9 @@ const ERROR_CODES = {
   MISSING_ELEMENT_IN_TABLE: "MISSING_ELEMENT_IN_TABLE",
   TYPE_MISMATCH_TABLE: "TYPE_MISMATCH_TABLE",
   NO_VALID_DATE: "NO_VALID_DATE",
+  INVALID_INTERVAL: "INVALID_INTERVAL",
+  MISSING_IMPL: "MISSING_IMPL",
+  DUPLICATE_EVENT_REGISTRATION: "DUPLICATE_EVENT_REGISTRATION",
 };
 
 const ERROR_CODES_META = {
@@ -42,6 +45,15 @@ const ERROR_CODES_META = {
   },
   [ERROR_CODES.NO_VALID_DATE]: {
     message: "One or more events contain a date in a malformed format.",
+  },
+  [ERROR_CODES.INVALID_INTERVAL]: {
+    message: "Invalid interval, the value needs to greater than 10 seconds.",
+  },
+  [ERROR_CODES.MISSING_IMPL]: {
+    message: "Missing path to event class implementation.",
+  },
+  [ERROR_CODES.DUPLICATE_EVENT_REGISTRATION]: {
+    message: "Duplicate event registration, check the uniqueness of type and subType.",
   },
 };
 
@@ -142,6 +154,39 @@ class EventQueueError extends VError {
       {
         name: ERROR_CODES.NO_VALID_DATE,
         info: { date },
+      },
+      message
+    );
+  }
+
+  static invalidInterval(type, subType, interval) {
+    const { message } = ERROR_CODES_META[ERROR_CODES.INVALID_INTERVAL];
+    return new EventQueueError(
+      {
+        name: ERROR_CODES.INVALID_INTERVAL,
+        info: { type, subType, interval },
+      },
+      message
+    );
+  }
+
+  static missingImpl(type, subType) {
+    const { message } = ERROR_CODES_META[ERROR_CODES.MISSING_IMPL];
+    return new EventQueueError(
+      {
+        name: ERROR_CODES.MISSING_IMPL,
+        info: { type, subType },
+      },
+      message
+    );
+  }
+
+  static duplicateEventRegistration(type, subType) {
+    const { message } = ERROR_CODES_META[ERROR_CODES.DUPLICATE_EVENT_REGISTRATION];
+    return new EventQueueError(
+      {
+        name: ERROR_CODES.DUPLICATE_EVENT_REGISTRATION,
+        info: { type, subType },
       },
       message
     );

--- a/src/EventQueueError.js
+++ b/src/EventQueueError.js
@@ -15,6 +15,7 @@ const ERROR_CODES = {
   INVALID_INTERVAL: "INVALID_INTERVAL",
   MISSING_IMPL: "MISSING_IMPL",
   DUPLICATE_EVENT_REGISTRATION: "DUPLICATE_EVENT_REGISTRATION",
+  NO_MANUEL_INSERT_OF_PERIODIC: "NO_MANUEL_INSERT_OF_PERIODIC",
 };
 
 const ERROR_CODES_META = {
@@ -54,6 +55,9 @@ const ERROR_CODES_META = {
   },
   [ERROR_CODES.DUPLICATE_EVENT_REGISTRATION]: {
     message: "Duplicate event registration, check the uniqueness of type and subType.",
+  },
+  [ERROR_CODES.NO_MANUEL_INSERT_OF_PERIODIC]: {
+    message: "Periodic events are managed by the framework and are not allowed to insert manually.",
   },
 };
 
@@ -186,6 +190,17 @@ class EventQueueError extends VError {
     return new EventQueueError(
       {
         name: ERROR_CODES.DUPLICATE_EVENT_REGISTRATION,
+        info: { type, subType },
+      },
+      message
+    );
+  }
+
+  static manuelPeriodicEventInsert(type, subType) {
+    const { message } = ERROR_CODES_META[ERROR_CODES.NO_MANUEL_INSERT_OF_PERIODIC];
+    return new EventQueueError(
+      {
+        name: ERROR_CODES.NO_MANUEL_INSERT_OF_PERIODIC,
         info: { type, subType },
       },
       message

--- a/src/EventQueueProcessorBase.js
+++ b/src/EventQueueProcessorBase.js
@@ -7,7 +7,7 @@ const { EventProcessingStatus, TransactionMode } = require("./constants");
 const distributedLock = require("./shared/distributedLock");
 const EventQueueError = require("./EventQueueError");
 const { arrayToFlatMap } = require("./shared/common");
-const eventScheduler = require("./shared/EventScheduler");
+const eventScheduler = require("./shared/eventScheduler");
 const eventQueueConfig = require("./config");
 const PerformanceTracer = require("./shared/PerformanceTracer");
 

--- a/src/EventQueueProcessorBase.js
+++ b/src/EventQueueProcessorBase.js
@@ -842,7 +842,9 @@ class EventQueueProcessorBase {
       subType: this.#eventSubType,
       startAfter: new Date(new Date(queueEntry.startAfter).getTime() + interval * 1000),
     };
+    this.tx._skipEventQueueBroadcase = true;
     await this.tx.run(INSERT.into(this.#config.tableNameEventQueue).entries({ ...newEvent }));
+    this.tx._skipEventQueueBroadcase = false;
     if (interval < this.#config.runInterval) {
       this.#handleDelayedEvents([newEvent]);
     }

--- a/src/checkAndInsertPeriodicEvents.js
+++ b/src/checkAndInsertPeriodicEvents.js
@@ -3,7 +3,6 @@
 const cds = require("@sap/cds");
 
 const eventQueueConfig = require("./config");
-const eventScheduler = require("./shared/EventScheduler");
 const { publishEvent } = require("./publishEvent");
 
 const checkAndInsertPeriodicEvents = async (context) => {
@@ -28,7 +27,7 @@ const checkAndInsertPeriodicEvents = async (context) => {
 const insertAllEvents = async (tx) => {
   const configInstance = eventQueueConfig.getConfigInstance();
   const offset = configInstance.periodicEventOffset;
-  const baseDate = eventScheduler.getInstance().calculateFutureTime(new Date(), offset);
+  const baseDate = calculateFutureTime(new Date(), offset);
   const periodicEvents = configInstance.periodicEvents;
   const periodEventsInsert = periodicEvents.map((periodicEvent) => ({
     type: periodicEvent.type,
@@ -36,6 +35,12 @@ const insertAllEvents = async (tx) => {
     startAfter: baseDate,
   }));
   await publishEvent(tx, periodEventsInsert);
+};
+
+const calculateFutureTime = (date, seoncds) => {
+  const startAfterSeconds = date.getSeconds();
+  const secondsUntil = seoncds - (startAfterSeconds % seoncds);
+  return new Date(date.getTime() + secondsUntil * 1000);
 };
 
 module.exports = {

--- a/src/checkAndInsertPeriodicEvents.js
+++ b/src/checkAndInsertPeriodicEvents.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const cds = require("@sap/cds");
+
+const eventQueueConfig = require("./config");
+const eventScheduler = require("./shared/EventScheduler");
+const { publishEvent } = require("./publishEvent");
+
+const checkAndInsertPeriodicEvents = async (context) => {
+  const tx = cds.tx(context);
+  const configInstance = eventQueueConfig.getConfigInstance();
+  const baseCqn = SELECT.from(configInstance.tableNameEventQueue).where([
+    { list: [{ ref: ["type"] }, { ref: ["subType"] }] },
+    "IN",
+    {
+      list: configInstance.periodicEvents.map((periodicEvent) => ({
+        list: [{ val: periodicEvent.type }, { val: periodicEvent.subType }],
+      })),
+    },
+  ]);
+  const currentPeriodEvents = await tx.run(baseCqn);
+
+  if (!currentPeriodEvents.length) {
+    await insertAllEvents(tx);
+  }
+};
+
+const insertAllEvents = async (tx) => {
+  const configInstance = eventQueueConfig.getConfigInstance();
+  const offset = configInstance.periodicEventOffset;
+  const baseDate = eventScheduler.getInstance().calculateFutureTime(new Date(), offset);
+  const periodicEvents = configInstance.periodicEvents;
+  const periodEventsInsert = periodicEvents.map((periodicEvent) => ({
+    type: periodicEvent.type,
+    subType: periodicEvent.subType,
+    startAfter: baseDate,
+  }));
+  await publishEvent(tx, periodEventsInsert);
+};
+
+module.exports = {
+  checkAndInsertPeriodicEvents,
+};

--- a/src/checkAndInsertPeriodicEvents.js
+++ b/src/checkAndInsertPeriodicEvents.js
@@ -2,13 +2,17 @@
 
 const cds = require("@sap/cds");
 
-const eventQueueConfig = require("./config");
 const { publishEvent } = require("./publishEvent");
+const { EventProcessingStatus } = require("./constants");
+const { processChunkedSync } = require("./shared/common");
+const { getConfigInstance } = require("./config");
+
+const COMPONENT_NAME = "eventQueue/checkAndInsertPeriodicEvents";
 
 const checkAndInsertPeriodicEvents = async (context) => {
   const tx = cds.tx(context);
-  const configInstance = eventQueueConfig.getConfigInstance();
-  const baseCqn = SELECT.from(configInstance.tableNameEventQueue).where([
+  const configInstance = getConfigInstance();
+  const baseCqn = SELECT.distinct.from(configInstance.tableNameEventQueue).where([
     { list: [{ ref: ["type"] }, { ref: ["subType"] }] },
     "IN",
     {
@@ -16,24 +20,85 @@ const checkAndInsertPeriodicEvents = async (context) => {
         list: [{ val: periodicEvent.type }, { val: periodicEvent.subType }],
       })),
     },
+    "AND",
+    { ref: ["status"] },
+    "=",
+    { val: EventProcessingStatus.Open },
   ]);
   const currentPeriodEvents = await tx.run(baseCqn);
 
   if (!currentPeriodEvents.length) {
-    await insertAllEvents(tx);
+    // fresh insert all
+    return await insertPeriodEvents(tx, configInstance.periodicEvents);
   }
+
+  const exitingEventMap = currentPeriodEvents.reduce((result, current) => {
+    const key = _generateKey(current);
+    result[key] = current;
+    return result;
+  }, {});
+
+  const { newEvents, existingEvents } = configInstance.periodicEvents.reduce(
+    (result, event) => {
+      if (exitingEventMap[_generateKey(event)]) {
+        result.existingEvents.push(exitingEventMap[_generateKey(event)]);
+      } else {
+        result.newEvents.push(event);
+      }
+      return result;
+    },
+    { newEvents: [], existingEvents: [] }
+  );
+
+  const currentDate = new Date();
+  const exitingWithNotMatchingInterval = existingEvents.filter((existingEvent) => {
+    const config = configInstance.getEventConfig(existingEvent.type, existingEvent.subType);
+    const eventStartAfter = new Date(existingEvent.startAfter);
+    // check if to far in future
+    const dueInWithNewInterval = new Date(currentDate.getTime() + config.interval * 1000);
+    return eventStartAfter >= dueInWithNewInterval;
+  });
+
+  exitingWithNotMatchingInterval.length &&
+    cds.log(COMPONENT_NAME).info("deleting periodic events because they have changed", {
+      changedEvents: exitingWithNotMatchingInterval.map(({ type, subType }) => ({ type, subType })),
+    });
+  await tx.run(
+    DELETE.from(configInstance.tableNameEventQueue).where(
+      "ID IN",
+      exitingWithNotMatchingInterval.map(({ ID }) => ID)
+    )
+  );
+
+  const newOrChangedEvents = newEvents.concat(exitingWithNotMatchingInterval);
+
+  if (!newOrChangedEvents.length) {
+    return;
+  }
+
+  return await insertPeriodEvents(tx, newOrChangedEvents);
 };
 
-const insertAllEvents = async (tx) => {
-  const configInstance = eventQueueConfig.getConfigInstance();
-  const periodicEvents = configInstance.periodicEvents;
-  const periodEventsInsert = periodicEvents.map((periodicEvent) => ({
+const insertPeriodEvents = async (tx, events) => {
+  const startAfter = new Date();
+  const configInstance = getConfigInstance();
+  processChunkedSync(events, 4, (chunk) => {
+    cds.log(COMPONENT_NAME).info("inserting changed or new periodic events", {
+      events: chunk.map(({ type, subType }) => {
+        const { interval } = configInstance.getEventConfig(type, subType);
+        return { type, subType, interval };
+      }),
+    });
+  });
+  const periodEventsInsert = events.map((periodicEvent) => ({
     type: periodicEvent.type,
     subType: periodicEvent.subType,
-    startAfter: new Date(),
+    startAfter: startAfter,
   }));
   await publishEvent(tx, periodEventsInsert, true);
 };
+
+const _generateKey = ({ type, subType }) => [type, subType].join("##");
 
 module.exports = {
   checkAndInsertPeriodicEvents,

--- a/src/checkAndInsertPeriodicEvents.js
+++ b/src/checkAndInsertPeriodicEvents.js
@@ -12,19 +12,21 @@ const COMPONENT_NAME = "eventQueue/checkAndInsertPeriodicEvents";
 const checkAndInsertPeriodicEvents = async (context) => {
   const tx = cds.tx(context);
   const configInstance = getConfigInstance();
-  const baseCqn = SELECT.distinct.from(configInstance.tableNameEventQueue).where([
-    { list: [{ ref: ["type"] }, { ref: ["subType"] }] },
-    "IN",
-    {
-      list: configInstance.periodicEvents.map((periodicEvent) => ({
-        list: [{ val: periodicEvent.type }, { val: periodicEvent.subType }],
-      })),
-    },
-    "AND",
-    { ref: ["status"] },
-    "=",
-    { val: EventProcessingStatus.Open },
-  ]);
+  const baseCqn = SELECT.from(configInstance.tableNameEventQueue)
+    .where([
+      { list: [{ ref: ["type"] }, { ref: ["subType"] }] },
+      "IN",
+      {
+        list: configInstance.periodicEvents.map((periodicEvent) => ({
+          list: [{ val: periodicEvent.type }, { val: periodicEvent.subType }],
+        })),
+      },
+      "AND",
+      { ref: ["status"] },
+      "=",
+      { val: EventProcessingStatus.Open },
+    ])
+    .columns(["ID", "type", "subType", "startAfter"]);
   const currentPeriodEvents = await tx.run(baseCqn);
 
   if (!currentPeriodEvents.length) {

--- a/src/checkAndInsertPeriodicEvents.js
+++ b/src/checkAndInsertPeriodicEvents.js
@@ -26,21 +26,13 @@ const checkAndInsertPeriodicEvents = async (context) => {
 
 const insertAllEvents = async (tx) => {
   const configInstance = eventQueueConfig.getConfigInstance();
-  const offset = configInstance.periodicEventOffset;
-  const baseDate = calculateFutureTime(new Date(), offset);
   const periodicEvents = configInstance.periodicEvents;
   const periodEventsInsert = periodicEvents.map((periodicEvent) => ({
     type: periodicEvent.type,
     subType: periodicEvent.subType,
-    startAfter: baseDate,
+    startAfter: new Date(),
   }));
-  await publishEvent(tx, periodEventsInsert);
-};
-
-const calculateFutureTime = (date, seoncds) => {
-  const startAfterSeconds = date.getSeconds();
-  const secondsUntil = seoncds - (startAfterSeconds % seoncds);
-  return new Date(date.getTime() + secondsUntil * 1000);
+  await publishEvent(tx, periodEventsInsert, true);
 };
 
 module.exports = {

--- a/src/config.js
+++ b/src/config.js
@@ -31,6 +31,7 @@ class Config {
   #env;
   #eventMap;
   #periodicEventOffset;
+  #updatePeriodicEvents;
   constructor() {
     this.#logger = cds.log(COMPONENT_NAME);
     this.#config = null;
@@ -238,6 +239,14 @@ class Config {
 
   get periodicEventOffset() {
     return this.#periodicEventOffset;
+  }
+
+  set updatePeriodicEvents(value) {
+    this.#updatePeriodicEvents = value;
+  }
+
+  get updatePeriodicEvents() {
+    return this.#updatePeriodicEvents;
   }
 
   get isMultiTenancy() {

--- a/src/dbHandler.js
+++ b/src/dbHandler.js
@@ -11,6 +11,9 @@ const registerEventQueueDbHandler = (dbService) => {
   const configInstance = config.getConfigInstance();
   const def = dbService.model.definitions[configInstance.tableNameEventQueue];
   dbService.after("CREATE", def, (_, req) => {
+    if (req.tx._skipEventQueueBroadcase) {
+      return;
+    }
     req.tx._ = req.tx._ ?? {};
     req.tx._.eventQueuePublishEvents = req.tx._.eventQueuePublishEvents ?? {};
     const eventQueuePublishEvents = req.tx._.eventQueuePublishEvents;

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -120,17 +120,19 @@ const registerEventProcessors = () => {
     return;
   }
 
+  const errorHandler = (err) => cds.log(COMPONENT).error("error during init runner", err);
+
   if (!configInstance.isMultiTenancy) {
-    runner.singleTenant();
+    runner.singleTenant().catch(errorHandler);
     return;
   }
 
   if (configInstance.redisEnabled) {
     initEventQueueRedisSubscribe();
     configInstance.attachConfigChangeHandler();
-    runner.multiTenancyRedis();
+    runner.multiTenancyRedis().catch(errorHandler);
   } else {
-    runner.multiTenancyDb();
+    runner.multiTenancyDb().catch(errorHandler);
   }
 };
 

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -34,6 +34,7 @@ const CONFIG_VARS = [
   ["tableNameEventLock", BASE_TABLES.LOCK],
   ["disableRedis", false],
   ["skipCsnCheck", false],
+  ["updatePeriodicEvents", true],
 ];
 
 const initialize = async ({
@@ -47,6 +48,7 @@ const initialize = async ({
   tableNameEventLock,
   disableRedis,
   skipCsnCheck,
+  updatePeriodicEvents,
 } = {}) => {
   // TODO: initialize check:
   // - content of yaml check
@@ -68,7 +70,8 @@ const initialize = async ({
     tableNameEventQueue,
     tableNameEventLock,
     disableRedis,
-    skipCsnCheck
+    skipCsnCheck,
+    updatePeriodicEvents
   );
 
   const logger = cds.log(COMPONENT);

--- a/src/periodicEvents.js
+++ b/src/periodicEvents.js
@@ -2,7 +2,6 @@
 
 const cds = require("@sap/cds");
 
-const { publishEvent } = require("./publishEvent");
 const { EventProcessingStatus } = require("./constants");
 const { processChunkedSync } = require("./shared/common");
 const { getConfigInstance } = require("./config");
@@ -97,7 +96,10 @@ const insertPeriodEvents = async (tx, events) => {
     subType: periodicEvent.subType,
     startAfter: startAfter,
   }));
-  await publishEvent(tx, periodEventsInsert, true);
+
+  tx._skipEventQueueBroadcase = true;
+  await tx.run(INSERT.into(configInstance.tableNameEventQueue).entries(periodEventsInsert));
+  tx._skipEventQueueBroadcase = false;
 };
 
 const _generateKey = ({ type, subType }) => [type, subType].join("##");

--- a/src/periodicEvents.js
+++ b/src/periodicEvents.js
@@ -7,7 +7,7 @@ const { EventProcessingStatus } = require("./constants");
 const { processChunkedSync } = require("./shared/common");
 const { getConfigInstance } = require("./config");
 
-const COMPONENT_NAME = "eventQueue/checkAndInsertPeriodicEvents";
+const COMPONENT_NAME = "eventQueue/periodicEvents";
 
 const checkAndInsertPeriodicEvents = async (context) => {
   const tx = cds.tx(context);

--- a/src/processEventQueue.js
+++ b/src/processEventQueue.js
@@ -239,7 +239,7 @@ const _processEvent = async (eventTypeInstance, processContext, key, queueEntrie
     }
     eventTypeInstance.setTxForEventProcessing(key, cds.tx(processContext));
     const statusTuple = await eventTypeInstance.processEvent(processContext, key, queueEntries, payload);
-    return eventTypeInstance.isPeriodicEvent && eventTypeInstance.setEventStatus(queueEntries, statusTuple);
+    return eventTypeInstance.setEventStatus(queueEntries, statusTuple);
   } catch (err) {
     return eventTypeInstance.handleErrorDuringProcessing(err, queueEntries);
   }

--- a/src/processEventQueue.js
+++ b/src/processEventQueue.js
@@ -170,6 +170,13 @@ const processPeriodicEvent = async (eventTypeInstance) => {
           await eventTypeInstance.processEvent(tx.context, queueEntry.ID, [queueEntry]);
         } catch (err) {
           eventTypeInstance.handleErrorDuringPeriodicEventProcessing(err, queueEntry);
+          throw new TriggerRollback();
+        }
+        if (
+          eventTypeInstance.transactionMode !== TransactionMode.alwaysCommit ||
+          eventTypeInstance.shouldRollbackTransaction(queueEntry.ID)
+        ) {
+          throw new TriggerRollback();
         }
       }
     );

--- a/src/publishEvent.js
+++ b/src/publishEvent.js
@@ -41,6 +41,10 @@ const publishEvent = async (tx, events, skipBroadcast = false) => {
     if (startAfter && !common.isValidDate(startAfter)) {
       throw EventQueueError.malformedDate(startAfter);
     }
+
+    if (eventConfig.isPeriodic) {
+      throw EventQueueError.manuelPeriodicEventInsert(type, subType);
+    }
   }
   tx._skipEventQueueBroadcase = skipBroadcast;
   const result = await tx.run(INSERT.into(configInstance.tableNameEventQueue).entries(eventsForProcessing));

--- a/src/runner.js
+++ b/src/runner.js
@@ -9,7 +9,7 @@ const cdsHelper = require("./shared/cdsHelper");
 const distributedLock = require("./shared/distributedLock");
 const SetIntervalDriftSafe = require("./shared/SetIntervalDriftSafe");
 const { getSubdomainForTenantId } = require("./shared/cdsHelper");
-const { checkAndInsertPeriodicEvents } = require("./checkAndInsertPeriodicEvents");
+const periodicEvents = require("./periodicEvents");
 const { hashStringTo32Bit } = require("./shared/common");
 
 const COMPONENT_NAME = "eventQueue/runner";
@@ -269,7 +269,7 @@ const _checkPeriodicEventsSingleTenant = async (tenantId) => {
       subdomain,
     });
     await cdsHelper.executeInNewTransaction(context, "update-periodic-events", async (tx) => {
-      await checkAndInsertPeriodicEvents(tx.context);
+      await periodicEvents.checkAndInsertPeriodicEvents(tx.context);
     });
   } catch (err) {
     logger.error(`Couldn't process eventQueue for tenant! Next try after defined interval. Error: ${err}`, {

--- a/src/runner.js
+++ b/src/runner.js
@@ -9,18 +9,19 @@ const cdsHelper = require("./shared/cdsHelper");
 const distributedLock = require("./shared/distributedLock");
 const SetIntervalDriftSafe = require("./shared/SetIntervalDriftSafe");
 const { getSubdomainForTenantId } = require("./shared/cdsHelper");
-const { checkAnsInsertPeriodicEvents } = require("./checkAndInsertPeriodicEvents");
+const { checkAndInsertPeriodicEvents } = require("./checkAndInsertPeriodicEvents");
 
 const COMPONENT_NAME = "eventQueue/runner";
 const EVENT_QUEUE_RUN_ID = "EVENT_QUEUE_RUN_ID";
 const EVENT_QUEUE_RUN_TS = "EVENT_QUEUE_RUN_TS";
+const EVENT_QUEUE_RUN_PERIODIC_EVENT = "EVENT_QUEUE_RUN_PERIODIC_EVENT";
 const OFFSET_FIRST_RUN = 10 * 1000;
 
-const singleTenant = () => _scheduleFunction(checkPeriodicEventsSingleTenant, _executeRunForTenant);
+const singleTenant = () => _scheduleFunction(_checkPeriodicEventsSingleTenant, _executeRunForTenant);
 
-const multiTenancyDb = () => _scheduleFunction(checkPeriodicEventsSingleTenant, _multiTenancyDb);
+const multiTenancyDb = () => _scheduleFunction(_multiTenancyPeriodicEventsDb, _multiTenancyDb);
 
-const multiTenancyRedis = () => _scheduleFunction(checkPeriodicEventsSingleTenant, _multiTenancyRedis);
+const multiTenancyRedis = () => _scheduleFunction(_checkPeriodicEventsSingleTenant, _multiTenancyRedis);
 
 const _scheduleFunction = async (singleRunFn, periodicFn) => {
   const logger = cds.log(COMPONENT_NAME);
@@ -47,8 +48,8 @@ const _scheduleFunction = async (singleRunFn, periodicFn) => {
   });
 
   setTimeout(() => {
-    fnWithRunningCheck();
     singleRunFn();
+    fnWithRunningCheck();
     const intervalRunner = new SetIntervalDriftSafe(configInstance.runInterval);
     intervalRunner.run(fnWithRunningCheck);
   }, offsetDependingOnLastRun).unref();
@@ -69,20 +70,7 @@ const _multiTenancyRedis = async () => {
   _executeAllTenants(tenantIds, runId);
 };
 
-const _multiTenancyDb = async () => {
-  const logger = cds.log(COMPONENT_NAME);
-  try {
-    logger.info("executing event queue run for single instance and multi tenant");
-    const tenantIds = await cdsHelper.getAllTenantIds();
-    _executeAllTenants(tenantIds, EVENT_QUEUE_RUN_ID);
-  } catch (err) {
-    logger.error(
-      `Couldn't fetch tenant ids for event queue processing! Next try after defined interval. Error: ${err}`
-    );
-  }
-};
-
-const _executeAllTenants = (tenantIds, runId) => {
+const _executeAllTenantsGeneric = (tenantIds, runId, fn) => {
   const configInstance = eventQueueConfig.getConfigInstance();
   const workerQueueInstance = getWorkerPoolInstance();
   tenantIds.forEach((tenantId) => {
@@ -95,7 +83,7 @@ const _executeAllTenants = (tenantIds, runId) => {
         if (!couldAcquireLock) {
           return;
         }
-        await _executeRunForTenant(tenantId, runId);
+        await fn(tenantId, runId);
       } catch (err) {
         cds.log(COMPONENT_NAME).error("executing event-queue run for tenant failed", {
           tenantId,
@@ -104,6 +92,11 @@ const _executeAllTenants = (tenantIds, runId) => {
     });
   });
 };
+
+const _executeAllTenants = (tenantIds, runId) => _executeAllTenantsGeneric(tenantIds, runId, _executeRunForTenant);
+
+const _executePeriodicEventsAllTenants = (tenantIds, runId) =>
+  _executeAllTenantsGeneric(tenantIds, runId, _checkPeriodicEventsSingleTenant);
 
 const _executeRunForTenant = async (tenantId, runId) => {
   const logger = cds.log(COMPONENT_NAME);
@@ -213,7 +206,33 @@ const runEventCombinationForTenant = async (tenantId, type, subType) => {
   }
 };
 
-const checkPeriodicEventsSingleTenant = async (tenantId) => {
+const _multiTenancyDb = async () => {
+  const logger = cds.log(COMPONENT_NAME);
+  try {
+    logger.info("executing event queue run for single instance and multi tenant");
+    const tenantIds = await cdsHelper.getAllTenantIds();
+    _executeAllTenants(tenantIds, EVENT_QUEUE_RUN_ID);
+  } catch (err) {
+    logger.error(
+      `Couldn't fetch tenant ids for event queue processing! Next try after defined interval. Error: ${err}`
+    );
+  }
+};
+
+const _multiTenancyPeriodicEventsDb = async () => {
+  const logger = cds.log(COMPONENT_NAME);
+  try {
+    logger.info("executing event queue update periodic events");
+    const tenantIds = await cdsHelper.getAllTenantIds();
+    _executePeriodicEventsAllTenants(tenantIds, EVENT_QUEUE_RUN_PERIODIC_EVENT);
+  } catch (err) {
+    logger.error(
+      `Couldn't fetch tenant ids for event queue processing! Next try after defined interval. Error: ${err}`
+    );
+  }
+};
+
+const _checkPeriodicEventsSingleTenant = async (tenantId) => {
   const logger = cds.log(COMPONENT_NAME);
   const configInstance = eventQueueConfig.getConfigInstance();
   try {
@@ -224,11 +243,13 @@ const checkPeriodicEventsSingleTenant = async (tenantId) => {
       http: { req: { authInfo: { getSubdomain: () => subdomain } } },
     });
     cds.context = context;
-    logger.info("executing eventQueue run", {
+    logger.info("executing updating periotic events", {
       tenantId,
       subdomain,
     });
-    await checkAnsInsertPeriodicEvents(context);
+    await cdsHelper.executeInNewTransaction(context, "update-periodic-events", async (tx) => {
+      await checkAndInsertPeriodicEvents(tx.context);
+    });
   } catch (err) {
     logger.error(`Couldn't process eventQueue for tenant! Next try after defined interval. Error: ${err}`, {
       tenantId,

--- a/src/runner.js
+++ b/src/runner.js
@@ -235,6 +235,9 @@ const _multiTenancyPeriodicEventsDb = async () => {
 const _checkPeriodicEventsSingleTenant = async (tenantId) => {
   const logger = cds.log(COMPONENT_NAME);
   const configInstance = eventQueueConfig.getConfigInstance();
+  if (!configInstance.updatePeriodicEvents) {
+    logger.info("updating of periodic events is disabled");
+  }
   try {
     const subdomain = await cdsHelper.getSubdomainForTenantId(tenantId);
     const context = new cds.EventContext({

--- a/src/shared/EventScheduler.js
+++ b/src/shared/EventScheduler.js
@@ -12,9 +12,7 @@ class EventScheduler {
   constructor() {}
 
   scheduleEvent(tenantId, type, subType, startAfter) {
-    const startAfterSeconds = startAfter.getSeconds();
-    const secondsUntilNextTen = 10 - (startAfterSeconds % 10);
-    const roundUpDate = new Date(startAfter.getTime() + secondsUntilNextTen * 1000);
+    const roundUpDate = this.calculateFutureTime(startAfter, 10);
     const key = [tenantId, type, subType, roundUpDate.toISOString()].join("##");
     if (this.#scheduledEvents[key]) {
       return; // event combination already scheduled
@@ -36,6 +34,12 @@ class EventScheduler {
         });
       });
     }, roundUpDate.getTime() - Date.now()).unref();
+  }
+
+  calculateFutureTime(date, seoncds) {
+    const startAfterSeconds = date.getSeconds();
+    const secondsUntil = seoncds - (startAfterSeconds % seoncds);
+    return new Date(date.getTime() + secondsUntil * 1000);
   }
 
   clearScheduledEvents() {

--- a/src/shared/common.js
+++ b/src/shared/common.js
@@ -118,4 +118,14 @@ const isValidDate = (value) => {
   }
 };
 
-module.exports = { arrayToFlatMap, Funnel, limiter, isValidDate };
+const processChunkedSync = (inputs, chunkSize, chunkHandler) => {
+  let start = 0;
+  while (start < inputs.length) {
+    let end = start + chunkSize > inputs.length ? inputs.length : start + chunkSize;
+    const chunk = inputs.slice(start, end);
+    chunkHandler(chunk);
+    start = end;
+  }
+};
+
+module.exports = { arrayToFlatMap, Funnel, limiter, isValidDate, processChunkedSync };

--- a/src/shared/common.js
+++ b/src/shared/common.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const crypto = require("crypto");
+
 const { floor, abs, min } = Math;
 
 const arrayToFlatMap = (array, key = "ID") => {
@@ -128,4 +130,6 @@ const processChunkedSync = (inputs, chunkSize, chunkHandler) => {
   }
 };
 
-module.exports = { arrayToFlatMap, Funnel, limiter, isValidDate, processChunkedSync };
+const hashStringTo32Bit = (value) => crypto.createHash("sha256").update(String(value)).digest("base64").slice(0, 32);
+
+module.exports = { arrayToFlatMap, Funnel, limiter, isValidDate, processChunkedSync, hashStringTo32Bit };

--- a/src/shared/eventScheduler.js
+++ b/src/shared/eventScheduler.js
@@ -5,7 +5,7 @@ const cds = require("@sap/cds");
 const { broadcastEvent } = require("../redisPubSub");
 const config = require("./../config");
 
-const COMPONENT_NAME = "eventQueue/shared/EventScheduler";
+const COMPONENT_NAME = "eventQueue/shared/eventScheduler";
 
 let instance;
 class EventScheduler {

--- a/test-integration/__snapshots__/integration-main.test.js.snap
+++ b/test-integration/__snapshots__/integration-main.test.js.snap
@@ -237,6 +237,7 @@ exports[`integration-main transactionMode=alwaysCommit one green with register r
 [
   {
     "attempts": 1,
+    "startAfter": null,
     "status": 2,
   },
 ]
@@ -258,14 +259,17 @@ exports[`integration-main transactionMode=alwaysCommit one with error + one with
 [
   {
     "attempts": 0,
+    "startAfter": null,
     "status": 0,
   },
   {
     "attempts": 1,
+    "startAfter": null,
     "status": 2,
   },
   {
     "attempts": 1,
+    "startAfter": null,
     "status": 3,
   },
 ]
@@ -287,6 +291,7 @@ exports[`integration-main transactionMode=alwaysRollback one green --> tx rollba
 [
   {
     "attempts": 1,
+    "startAfter": null,
     "status": 2,
   },
 ]
@@ -308,10 +313,12 @@ exports[`integration-main transactionMode=alwaysRollback one with error + one wi
 [
   {
     "attempts": 1,
+    "startAfter": null,
     "status": 2,
   },
   {
     "attempts": 1,
+    "startAfter": null,
     "status": 3,
   },
 ]
@@ -333,14 +340,17 @@ exports[`integration-main transactionMode=isolated first processed register tx r
 [
   {
     "attempts": 1,
+    "startAfter": null,
     "status": 2,
   },
   {
     "attempts": 0,
+    "startAfter": null,
     "status": 0,
   },
   {
     "attempts": 1,
+    "startAfter": null,
     "status": 2,
   },
 ]

--- a/test-integration/__snapshots__/integration-main.test.js.snap
+++ b/test-integration/__snapshots__/integration-main.test.js.snap
@@ -180,6 +180,29 @@ exports[`integration-main lock wait timeout during keepAlive 1`] = `
 }
 `;
 
+exports[`integration-main periodic events transactions modes always commit 1`] = `
+{
+  "BEGIN": 6,
+  "COMMIT": 6,
+  "CREATE": 1,
+  "DELETE": 2,
+  "READ": 2,
+  "UPDATE": 2,
+}
+`;
+
+exports[`integration-main periodic events transactions modes always rollback 1`] = `
+{
+  "BEGIN": 6,
+  "COMMIT": 5,
+  "CREATE": 1,
+  "DELETE": 2,
+  "READ": 2,
+  "ROLLBACK": 1,
+  "UPDATE": 2,
+}
+`;
+
 exports[`integration-main returning exceeded status should be allowed 1`] = `
 {
   "BEGIN": 8,

--- a/test-integration/integration-main.test.js
+++ b/test-integration/integration-main.test.js
@@ -776,6 +776,7 @@ describe("integration-main", () => {
 
   describe("end-to-end", () => {
     beforeAll(async () => {
+      checkAndInsertPeriodicEventsMock = jest.spyOn(periodicEvents, "checkAndInsertPeriodicEvents").mockResolvedValue();
       eventQueue.getConfigInstance().initialized = false;
       const configFilePath = path.join(__dirname, "..", "./test", "asset", "config.yml");
       await eventQueue.initialize({

--- a/test-integration/integration-main.test.js
+++ b/test-integration/integration-main.test.js
@@ -640,34 +640,6 @@ describe("integration-main", () => {
     });
   });
 
-  describe("end-to-end", () => {
-    beforeAll(async () => {
-      eventQueue.getConfigInstance().initialized = false;
-      const configFilePath = path.join(__dirname, "..", "./test", "asset", "config.yml");
-      await eventQueue.initialize({
-        configFilePath,
-        processEventsAfterPublish: true,
-      });
-    });
-
-    it("insert entry, entry should be automatically processed", async () => {
-      await cds.tx({}, (tx2) => testHelper.insertEventEntry(tx2));
-      await waitEntryIsDone();
-      expect(loggerMock.callsLengths().error).toEqual(0);
-      await testHelper.selectEventQueueAndExpectDone(tx);
-    });
-
-    it("insert one delayed entry and process - should be processed after timeout", async () => {
-      await cds.tx({}, (tx2) => testHelper.insertEventEntry(tx2, { delayedSeconds: 5 }));
-      const event = eventQueue.getConfigInstance().events[0];
-      await eventQueue.processEventQueue(context, event.type, event.subType);
-      expect(loggerMock.callsLengths().error).toEqual(0);
-      await testHelper.selectEventQueueAndExpectOpen(tx);
-      await waitEntryIsDone();
-      await testHelper.selectEventQueueAndExpectDone(tx);
-    });
-  });
-
   describe("periodic events", () => {
     beforeAll(async () => {
       eventQueue.getConfigInstance().initialized = false;
@@ -799,6 +771,34 @@ describe("integration-main", () => {
 
         await testHelper.selectEventQueueAndExpectDone(tx);
       });
+    });
+  });
+
+  describe("end-to-end", () => {
+    beforeAll(async () => {
+      eventQueue.getConfigInstance().initialized = false;
+      const configFilePath = path.join(__dirname, "..", "./test", "asset", "config.yml");
+      await eventQueue.initialize({
+        configFilePath,
+        processEventsAfterPublish: true,
+      });
+    });
+
+    it("insert entry, entry should be automatically processed", async () => {
+      await cds.tx({}, (tx2) => testHelper.insertEventEntry(tx2));
+      await waitEntryIsDone();
+      expect(loggerMock.callsLengths().error).toEqual(0);
+      await testHelper.selectEventQueueAndExpectDone(tx);
+    });
+
+    it("insert one delayed entry and process - should be processed after timeout", async () => {
+      await cds.tx({}, (tx2) => testHelper.insertEventEntry(tx2, { delayedSeconds: 5 }));
+      const event = eventQueue.getConfigInstance().events[0];
+      await eventQueue.processEventQueue(context, event.type, event.subType);
+      expect(loggerMock.callsLengths().error).toEqual(0);
+      await testHelper.selectEventQueueAndExpectOpen(tx);
+      await waitEntryIsDone();
+      await testHelper.selectEventQueueAndExpectDone(tx);
     });
   });
 });

--- a/test-integration/integration-main.test.js
+++ b/test-integration/integration-main.test.js
@@ -15,6 +15,10 @@ const { EventProcessingStatus } = require("../src");
 const { Logger: mockLogger } = require("../test/mocks/logger");
 const distributedLock = require("../src/shared/distributedLock");
 
+jest.mock("../src/checkAndInsertPeriodicEvents", () => ({
+  checkAndInsertPeriodicEvents: jest.fn().mockResolvedValue(),
+}));
+
 let dbCounts = {};
 describe("integration-main", () => {
   let context;

--- a/test/EventScheduler.test.js
+++ b/test/EventScheduler.test.js
@@ -2,7 +2,7 @@
 
 const cds = require("@sap/cds");
 
-const { getInstance: getEventSchedulerInstance } = require("../src/shared/EventScheduler");
+const { getInstance: getEventSchedulerInstance } = require("../src/shared/eventScheduler");
 const { getConfigInstance } = require("../src/config");
 const { broadcastEvent } = require("../src/redisPubSub");
 

--- a/test/EventScheduler.test.js
+++ b/test/EventScheduler.test.js
@@ -2,7 +2,8 @@
 
 const cds = require("@sap/cds");
 
-const EventScheduler = require("../src/shared/EventScheduler").getInstance;
+const { getInstance: getEventSchedulerInstance } = require("../src/shared/EventScheduler");
+const { getConfigInstance } = require("../src/config");
 const { broadcastEvent } = require("../src/redisPubSub");
 
 jest.mock("@sap/cds", () => ({
@@ -30,7 +31,12 @@ describe("EventScheduler", () => {
   });
 
   beforeAll(() => {
-    eventScheduler = EventScheduler();
+    eventScheduler = getEventSchedulerInstance();
+    const configInstance = getConfigInstance();
+    jest.spyOn(configInstance, "getEventConfig").mockReturnValue({
+      interval: 60,
+    });
+    jest.spyOn(configInstance, "isPeriodicEvent").mockReturnValue(false);
     jest.useFakeTimers();
   });
 

--- a/test/__snapshots__/baseFunctionality.test.js.snap
+++ b/test/__snapshots__/baseFunctionality.test.js.snap
@@ -79,3 +79,13 @@ exports[`baseFunctionality ad-hoc events error handling missing event implementa
   ],
 ]
 `;
+
+exports[`baseFunctionality periodic events two open events - not allowed 1`] = `
+[
+  "More than one open events for the same configuration which is not allowed!",
+  {
+    "eventSubType": "DB",
+    "eventType": "HealthCheck",
+  },
+]
+`;

--- a/test/__snapshots__/baseFunctionality.test.js.snap
+++ b/test/__snapshots__/baseFunctionality.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`baseFunctionality error handling handle checkEventAndGeneratePayload fails 1`] = `
+exports[`baseFunctionality ad-hoc events error handling handle checkEventAndGeneratePayload fails 1`] = `
 [
   [
     "Caught error during event processing - setting queue entry to error. Please catch your promises/exceptions. Error: Error: syntax error",
@@ -15,7 +15,7 @@ exports[`baseFunctionality error handling handle checkEventAndGeneratePayload fa
 ]
 `;
 
-exports[`baseFunctionality error handling handle clusterQueueEntries fails 1`] = `
+exports[`baseFunctionality ad-hoc events error handling handle clusterQueueEntries fails 1`] = `
 [
   [
     "Error during clustering of events - setting all queue entries to error. Error: Error: syntax error",
@@ -27,7 +27,7 @@ exports[`baseFunctionality error handling handle clusterQueueEntries fails 1`] =
 ]
 `;
 
-exports[`baseFunctionality error handling handle getQueueEntriesAndSetToInProgress fails 1`] = `
+exports[`baseFunctionality ad-hoc events error handling handle getQueueEntriesAndSetToInProgress fails 1`] = `
 [
   [
     "Processing event queue failed with unexpected error. Error:",
@@ -40,7 +40,7 @@ exports[`baseFunctionality error handling handle getQueueEntriesAndSetToInProgre
 ]
 `;
 
-exports[`baseFunctionality error handling handle handleDistributedLock fails 1`] = `
+exports[`baseFunctionality ad-hoc events error handling handle handleDistributedLock fails 1`] = `
 [
   [
     "Processing event queue failed with unexpected error. Error:",
@@ -53,7 +53,7 @@ exports[`baseFunctionality error handling handle handleDistributedLock fails 1`]
 ]
 `;
 
-exports[`baseFunctionality error handling handle modifyQueueEntry fails 1`] = `
+exports[`baseFunctionality ad-hoc events error handling handle modifyQueueEntry fails 1`] = `
 [
   [
     "Caught error during event processing - setting queue entry to error. Please catch your promises/exceptions. Error: Error: syntax error",
@@ -68,7 +68,7 @@ exports[`baseFunctionality error handling handle modifyQueueEntry fails 1`] = `
 ]
 `;
 
-exports[`baseFunctionality error handling missing event implementation 1`] = `
+exports[`baseFunctionality ad-hoc events error handling missing event implementation 1`] = `
 [
   [
     "No Implementation found in the provided configuration file.",

--- a/test/__snapshots__/checkAndInsertPeriodicEvents.test.js.snap
+++ b/test/__snapshots__/checkAndInsertPeriodicEvents.test.js.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`baseFunctionality basic insert all new events 1`] = `
+[
+  [
+    "inserting changed or new periodic events",
+    {
+      "events": [
+        {
+          "interval": 30,
+          "subType": "DB",
+          "type": "HealthCheck",
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`baseFunctionality basic insert all new events 2`] = `
+[
+  {
+    "attempts": 0,
+    "startAfter": "2023-11-13T11:00:00.000Z",
+    "status": 0,
+  },
+]
+`;
+
+exports[`baseFunctionality delta insert 1`] = `
+[
+  [
+    "inserting changed or new periodic events",
+    {
+      "events": [
+        {
+          "interval": 30,
+          "subType": "DB",
+          "type": "HealthCheck",
+        },
+      ],
+    },
+  ],
+  [
+    "inserting changed or new periodic events",
+    {
+      "events": [
+        {
+          "interval": 30,
+          "subType": "DB2",
+          "type": "HealthCheck",
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`baseFunctionality delta insert 2`] = `
+[
+  {
+    "attempts": 0,
+    "startAfter": "2023-11-13T11:00:00.000Z",
+    "status": 0,
+  },
+  {
+    "attempts": 0,
+    "startAfter": "2023-11-13T11:00:00.000Z",
+    "status": 0,
+  },
+]
+`;
+
+exports[`baseFunctionality interval changed 1`] = `
+[
+  [
+    "inserting changed or new periodic events",
+    {
+      "events": [
+        {
+          "interval": 30,
+          "subType": "DB",
+          "type": "HealthCheck",
+        },
+      ],
+    },
+  ],
+  [
+    "deleting periodic events because they have changed",
+    {
+      "changedEvents": [
+        {
+          "subType": "DB",
+          "type": "HealthCheck",
+        },
+      ],
+    },
+  ],
+  [
+    "inserting changed or new periodic events",
+    {
+      "events": [
+        {
+          "interval": 10,
+          "subType": "DB",
+          "type": "HealthCheck",
+        },
+      ],
+    },
+  ],
+]
+`;
+
+exports[`baseFunctionality interval changed 2`] = `
+[
+  {
+    "attempts": 0,
+    "startAfter": "2023-11-13T11:00:00.000Z",
+    "status": 0,
+  },
+]
+`;

--- a/test/asset/EventQueueHealthCheckDb.js
+++ b/test/asset/EventQueueHealthCheckDb.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const EventQueueBaseClass = require("../../src/EventQueueProcessorBase");
+
+class EventQueueHealthCheckDb extends EventQueueBaseClass {
+  constructor(context, eventType, eventSubType, config) {
+    super(context, eventType, eventSubType, config);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  async processEvent(processContext, key, queueEntries, payload) {
+    await this.getTxForEventProcessing(key).run(SELECT.from("sap.eventqueue.Event"));
+  }
+}
+
+module.exports = EventQueueHealthCheckDb;

--- a/test/asset/config.yml
+++ b/test/asset/config.yml
@@ -47,3 +47,11 @@ events:
     parallelEventProcessing: 1
     processAfterCommit: true
     transactionMode: isolated
+
+periodicEvents:
+  - type: HealthCheck
+    subType: DB
+    impl: ./test/asset/EventQueueHealthCheckDb
+    load: 40
+    transactionMode: alwaysRollback
+    interval: 10

--- a/test/asset/config.yml
+++ b/test/asset/config.yml
@@ -54,4 +54,4 @@ periodicEvents:
     impl: ./test/asset/EventQueueHealthCheckDb
     load: 40
     transactionMode: alwaysRollback
-    interval: 10
+    interval: 30

--- a/test/baseFunctionality.test.js
+++ b/test/baseFunctionality.test.js
@@ -8,7 +8,7 @@ const cdsHelper = require("../src/shared/cdsHelper");
 const executeInNewTransactionSpy = jest.spyOn(cdsHelper, "executeInNewTransaction");
 
 const eventQueue = require("../src");
-const eventScheduler = require("../src/shared/EventScheduler");
+const eventScheduler = require("../src/shared/eventScheduler");
 const { checkAndInsertPeriodicEvents } = require("../src/checkAndInsertPeriodicEvents");
 const testHelper = require("./helper");
 const EventQueueTest = require("./asset/EventQueueTest");

--- a/test/baseFunctionality.test.js
+++ b/test/baseFunctionality.test.js
@@ -314,12 +314,15 @@ describe("baseFunctionality", () => {
 
       await eventQueue.processEventQueue(context, event.type, event.subType);
       expect(loggerMock.callsLengths().error).toEqual(1);
+      const log = loggerMock.calls().error[0];
+      delete log[1].queueEntriesIds;
+      expect(log).toMatchSnapshot();
       const events = await testHelper.selectEventQueueAndReturn(tx, 3);
       const [open, done1, done2] = events.sort((a, b) => a.status - b.status);
       expect(open).toEqual({
         status: EventProcessingStatus.Open,
         attempts: 0,
-        startAfter: new Date(new Date(done1.startAfter).getTime() + event.interval * 1000).toISOString(),
+        startAfter: expect.any(String),
       });
       expect(done1).toEqual({
         status: EventProcessingStatus.Done,

--- a/test/baseFunctionality.test.js
+++ b/test/baseFunctionality.test.js
@@ -9,7 +9,7 @@ const executeInNewTransactionSpy = jest.spyOn(cdsHelper, "executeInNewTransactio
 
 const eventQueue = require("../src");
 const eventScheduler = require("../src/shared/eventScheduler");
-const { checkAndInsertPeriodicEvents } = require("../src/checkAndInsertPeriodicEvents");
+const { checkAndInsertPeriodicEvents } = require("../src/periodicEvents");
 const testHelper = require("./helper");
 const EventQueueTest = require("./asset/EventQueueTest");
 const { Logger: mockLogger } = require("./mocks/logger");

--- a/test/checkAndInsertPeriodicEvents.test.js
+++ b/test/checkAndInsertPeriodicEvents.test.js
@@ -1,0 +1,88 @@
+"use strict";
+
+const path = require("path");
+
+const cds = require("@sap/cds/lib");
+
+const eventQueue = require("../src");
+const { Logger: mockLogger } = require("./mocks/logger");
+const { checkAndInsertPeriodicEvents } = require("../src/checkAndInsertPeriodicEvents");
+const { getConfigInstance } = require("../src/config");
+const { selectEventQueueAndReturn } = require("./helper");
+const project = __dirname + "/.."; // The project's root folder
+cds.test(project);
+
+describe("baseFunctionality", () => {
+  let loggerMock, context, tx;
+  beforeAll(async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(1699873200000));
+    const configFilePath = path.join(__dirname, "asset", "config.yml");
+    await eventQueue.initialize({
+      configFilePath,
+      processEventsAfterPublish: false,
+      registerAsEventProcessor: false,
+      updatePeriodicEvents: false,
+    });
+    loggerMock = mockLogger();
+    jest.spyOn(cds, "log").mockImplementation((layer) => {
+      return mockLogger(layer);
+    });
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    context = new cds.EventContext({ user: "testUser", tenant: 123 });
+    tx = cds.tx(context);
+    await tx.run(DELETE.from("sap.eventqueue.Lock"));
+    await tx.run(DELETE.from("sap.eventqueue.Event"));
+  });
+
+  afterEach(async () => {
+    await tx.rollback();
+  });
+
+  it("basic insert all new events", async () => {
+    await checkAndInsertPeriodicEvents(context);
+
+    expect(loggerMock.callsLengths().error).toEqual(0);
+    expect(loggerMock.calls().info).toMatchSnapshot();
+    expect(await selectEventQueueAndReturn(tx)).toMatchSnapshot();
+  });
+
+  it("delta insert", async () => {
+    await checkAndInsertPeriodicEvents(context);
+
+    const fileContent = getConfigInstance().fileContent;
+    fileContent.periodicEvents.push({
+      ...getConfigInstance().fileContent.periodicEvents[0],
+      subType: "DB2",
+    });
+    getConfigInstance().fileContent = fileContent;
+
+    await checkAndInsertPeriodicEvents(context);
+
+    fileContent.periodicEvents.splice(1, 1);
+    getConfigInstance().fileContent = fileContent;
+    expect(loggerMock.callsLengths().error).toEqual(0);
+    expect(loggerMock.calls().info).toMatchSnapshot();
+    expect(await selectEventQueueAndReturn(tx, 2)).toMatchSnapshot();
+  });
+
+  it("interval changed", async () => {
+    await checkAndInsertPeriodicEvents(context);
+    const eventConfig = getConfigInstance().periodicEvents[0];
+    eventConfig.interval = 10;
+
+    await tx.run(
+      UPDATE.entity("sap.eventqueue.Event").set({
+        startAfter: new Date(1699873200000 + 30 * 1000),
+      })
+    );
+    await checkAndInsertPeriodicEvents(context);
+
+    expect(loggerMock.callsLengths().error).toEqual(0);
+    expect(loggerMock.calls().info).toMatchSnapshot();
+    expect(await selectEventQueueAndReturn(tx, 1)).toMatchSnapshot();
+  });
+});

--- a/test/checkAndInsertPeriodicEvents.test.js
+++ b/test/checkAndInsertPeriodicEvents.test.js
@@ -6,7 +6,7 @@ const cds = require("@sap/cds/lib");
 
 const eventQueue = require("../src");
 const { Logger: mockLogger } = require("./mocks/logger");
-const { checkAndInsertPeriodicEvents } = require("../src/checkAndInsertPeriodicEvents");
+const { checkAndInsertPeriodicEvents } = require("../src/periodicEvents");
 const { getConfigInstance } = require("../src/config");
 const { selectEventQueueAndReturn } = require("./helper");
 const project = __dirname + "/.."; // The project's root folder

--- a/test/helper.js
+++ b/test/helper.js
@@ -74,7 +74,7 @@ const selectEventQueueAndExpectExceeded = async (tx, expectedLength = 1, attempt
   _selectEventQueueAndExpect(tx, EventProcessingStatus.Exceeded, expectedLength, attempts);
 
 const selectEventQueueAndReturn = async (tx, expectedLength = 1) => {
-  const events = await tx.run(SELECT.from("sap.eventqueue.Event").columns("status", "attempts"));
+  const events = await tx.run(SELECT.from("sap.eventqueue.Event").columns("status", "attempts", "startAfter"));
   expect(events).toHaveLength(expectedLength);
   return events;
 };

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -89,7 +89,7 @@ describe("initialize", () => {
 
   describe("runner mode registration", () => {
     test("single tenant", async () => {
-      const singleTenantSpy = jest.spyOn(runner, "singleTenant").mockReturnValueOnce();
+      const singleTenantSpy = jest.spyOn(runner, "singleTenant").mockResolvedValueOnce();
       await eventQueue.initialize({
         configFilePath,
         processEventsAfterPublish: false,
@@ -99,7 +99,7 @@ describe("initialize", () => {
 
     test("multi tenancy with db", async () => {
       cds.requires.multitenancy = {};
-      const multiTenancyDbSpy = jest.spyOn(runner, "multiTenancyDb").mockReturnValueOnce();
+      const multiTenancyDbSpy = jest.spyOn(runner, "multiTenancyDb").mockResolvedValueOnce();
       await eventQueue.initialize({
         configFilePath,
         processEventsAfterPublish: false,
@@ -109,7 +109,7 @@ describe("initialize", () => {
     });
 
     test("calling initialize twice should only processed once", async () => {
-      const singleTenant = jest.spyOn(runner, "singleTenant").mockReturnValueOnce();
+      const singleTenant = jest.spyOn(runner, "singleTenant").mockResolvedValueOnce();
       const p1 = eventQueue.initialize({
         configFilePath,
         processEventsAfterPublish: false,
@@ -129,7 +129,7 @@ describe("initialize", () => {
       env.vcapServices = {
         "redis-cache": [{ credentials: { hostname: "123" } }],
       };
-      const multiTenancyRedisSpy = jest.spyOn(runner, "multiTenancyRedis").mockReturnValueOnce();
+      const multiTenancyRedisSpy = jest.spyOn(runner, "multiTenancyRedis").mockResolvedValueOnce();
       await eventQueue.initialize({
         configFilePath,
         processEventsAfterPublish: false,
@@ -146,7 +146,7 @@ describe("initialize", () => {
       env.vcapServices = {
         "redis-cache": [{ credentials: { hostname: "123" } }],
       };
-      const multiTenancyRedisSpy = jest.spyOn(runner, "multiTenancyRedis").mockReturnValueOnce();
+      const multiTenancyRedisSpy = jest.spyOn(runner, "multiTenancyRedis").mockResolvedValueOnce();
       await eventQueue.initialize({
         configFilePath,
         processEventsAfterPublish: false,


### PR DESCRIPTION
fix https://github.com/cap-js-community/event-queue/issues/14

- [x] add new eventType: `periodic events`
- [x] periodicity should be defined every X seconds in yaml
- [x] during startup check persistence and schedule jobs
- [x] during selection - check that there is always one open entry
- [x] period jobs should have no status
- [x] check that there are no duplicated event type registrations
- [x] check period event registrations --> much less parameters
- [x] validations period not too small
- [x] also add event registration parameters for normal events
- [x] handle onboardings
- [x] do an extra run to schedule again for next processing - or maybe direclty during publish
- [x] test what happens if run is longer than interval
- [x] periodicEventOffset is currently not used anymore - delete?
- [x] publish should not allow periodic events


handle next:
- [ ] variable to skip run if already running
- [ ] periodic without tenant context (maybe do in next iteration)
- [ ] add info to documentation