### PR TITLE
Periodic fixes and test improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js-community/event-queue",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js-community/event-queue",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "redis": "4.6.10",
@@ -1413,9 +1413,9 @@
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.3.2.tgz",
-      "integrity": "sha512-jkh15G0f5CfUqT3bE2bgtLA83xgW7AK/KKjPV7AjLcN6Ygm5rKJnE73V0xaQIOxrdBCrH8oqbtXQ1csXgu0V9g==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.4.0.tgz",
+      "integrity": "sha512-VBzD1d7WBRZ6lZrPRhJS8fLoxdZgtHFRKLo+lcwIvYi3b2glJZ1h43yAZswq5iP83XE8ULtsiTosyr+g9ZSfRA==",
       "dev": true,
       "dependencies": {
         "antlr4": "4.9.3"
@@ -5597,9 +5597,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001561",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
-      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
+      "version": "1.0.30001562",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
+      "integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
       "dev": true,
       "funding": [
         {
@@ -5983,9 +5983,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.581",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.581.tgz",
-      "integrity": "sha512-6uhqWBIapTJUxgPTCHH9sqdbxIMPt7oXl0VcAL1kOtlU6aECdcMncCrX5Z7sHQ/invtrC9jUQUef7+HhO8vVFw==",
+      "version": "1.4.583",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.583.tgz",
+      "integrity": "sha512-93y1gcONABZ7uqYe/JWDVQP/Pj/sQSunF0HVAPdlg/pfBnOyBMLlQUxWvkqcljJg1+W6cjvPuYD+r1Th9Tn8mA==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js-community/event-queue",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "An event queue that enables secure transactional processing of asynchronous events, featuring instant event processing with Redis Pub/Sub and load distribution across all application instances.",
   "main": "src/index.js",
   "files": [

--- a/src/EventQueueProcessorBase.js
+++ b/src/EventQueueProcessorBase.js
@@ -31,37 +31,40 @@ class EventQueueProcessorBase {
   #eventType = null;
   #eventSubType = null;
   #config = null;
+  #eventSchedulerInstance = null;
+  #eventConfig;
 
   constructor(context, eventType, eventSubType, config) {
     this.__context = context;
     this.__baseContext = context;
     this.__tx = cds.tx(context);
     this.__baseLogger = cds.log(COMPONENT_NAME);
+    this.#eventSchedulerInstance = eventScheduler.getInstance();
     this.__logger = null;
     this.__eventProcessingMap = {};
     this.__statusMap = {};
     this.__commitedStatusMap = {};
     this.#eventType = eventType;
     this.#eventSubType = eventSubType;
-    this.__eventConfig = config ?? {};
-    this.__parallelEventProcessing = this.__eventConfig.parallelEventProcessing ?? DEFAULT_PARALLEL_EVENT_PROCESSING;
+    this.#eventConfig = config ?? {};
+    this.__parallelEventProcessing = this.#eventConfig.parallelEventProcessing ?? DEFAULT_PARALLEL_EVENT_PROCESSING;
     if (this.__parallelEventProcessing > LIMIT_PARALLEL_EVENT_PROCESSING) {
       this.__parallelEventProcessing = LIMIT_PARALLEL_EVENT_PROCESSING;
     }
     // NOTE: keep the feature, this might be needed again
     this.__concurrentEventProcessing = false;
-    this.__startTime = this.__eventConfig.startTime ?? new Date();
-    this.__retryAttempts = this.__eventConfig.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS;
-    this.__selectMaxChunkSize = this.__eventConfig.selectMaxChunkSize ?? SELECT_LIMIT_EVENTS_PER_TICK;
-    this.__selectNextChunk = !!this.__eventConfig.checkForNextChunk;
+    this.__startTime = this.#eventConfig.startTime ?? new Date();
+    this.__retryAttempts = this.#eventConfig.retryAttempts ?? DEFAULT_RETRY_ATTEMPTS;
+    this.__selectMaxChunkSize = this.#eventConfig.selectMaxChunkSize ?? SELECT_LIMIT_EVENTS_PER_TICK;
+    this.__selectNextChunk = !!this.#eventConfig.checkForNextChunk;
     this.__keepalivePromises = {};
-    this.__outdatedCheckEnabled = this.__eventConfig.eventOutdatedCheck ?? true;
-    this.__transactionMode = this.__eventConfig.transactionMode ?? TransactionMode.isolated;
-    if (this.__eventConfig.deleteFinishedEventsAfterDays) {
+    this.__outdatedCheckEnabled = this.#eventConfig.eventOutdatedCheck ?? true;
+    this.__transactionMode = this.#eventConfig.transactionMode ?? TransactionMode.isolated;
+    if (this.#eventConfig.deleteFinishedEventsAfterDays) {
       this.__deleteFinishedEventsAfter =
-        Number.isInteger(this.__eventConfig.deleteFinishedEventsAfterDays) &&
-        this.__eventConfig.deleteFinishedEventsAfterDays > 0
-          ? this.__eventConfig.deleteFinishedEventsAfterDays
+        Number.isInteger(this.#eventConfig.deleteFinishedEventsAfterDays) &&
+        this.#eventConfig.deleteFinishedEventsAfterDays > 0
+          ? this.#eventConfig.deleteFinishedEventsAfterDays
           : DEFAULT_DELETE_FINISHED_EVENTS_AFTER;
     } else {
       this.__deleteFinishedEventsAfter = DEFAULT_DELETE_FINISHED_EVENTS_AFTER;
@@ -610,9 +613,8 @@ class EventQueueProcessorBase {
   }
 
   #handleDelayedEvents(delayedEvents) {
-    const eventSchedulerInstance = eventScheduler.getInstance();
     for (const delayedEvent of delayedEvents) {
-      eventSchedulerInstance.scheduleEvent(
+      this.#eventSchedulerInstance.scheduleEvent(
         this.__context.tenant,
         this.#eventType,
         this.#eventSubType,
@@ -836,17 +838,42 @@ class EventQueueProcessorBase {
   }
 
   async scheduleNextPeriodEvent(queueEntry) {
-    const interval = this.__eventConfig.interval;
+    const interval = this.#eventConfig.interval;
     const newEvent = {
       type: this.#eventType,
       subType: this.#eventSubType,
       startAfter: new Date(new Date(queueEntry.startAfter).getTime() + interval * 1000),
     };
+    const { relative } = this.#eventSchedulerInstance.calculateOffset(
+      this.#eventType,
+      this.#eventSubType,
+      newEvent.startAfter
+    );
+
+    // more than one interval behind - shift tick to keep up
+    if (relative < 0 && Math.abs(relative) >= this.#eventConfig.interval * 1000) {
+      newEvent.startAfter = new Date(Date.now() + 5 * 1000);
+      this.logger.info("interval adjusted because shifted more than one interval", {
+        eventType: this.#eventType,
+        eventSubType: this.#eventSubType,
+        newStartAfter: newEvent.startAfter,
+      });
+    }
+
     this.tx._skipEventQueueBroadcase = true;
     await this.tx.run(INSERT.into(this.#config.tableNameEventQueue).entries({ ...newEvent }));
     this.tx._skipEventQueueBroadcase = false;
     if (interval < this.#config.runInterval) {
       this.#handleDelayedEvents([newEvent]);
+      const { relative: relativeAfterSchedule } = this.#eventSchedulerInstance.calculateOffset(
+        this.#eventType,
+        this.#eventSubType,
+        newEvent.startAfter
+      );
+      // next tick is already behind schedule --> execute direct
+      if (relativeAfterSchedule <= 0) {
+        return true;
+      }
     }
   }
 
@@ -986,7 +1013,7 @@ class EventQueueProcessorBase {
   }
 
   get isPeriodicEvent() {
-    return this.__eventConfig.isPeriodic;
+    return this.#eventConfig.isPeriodic;
   }
 }
 

--- a/src/EventQueueProcessorBase.js
+++ b/src/EventQueueProcessorBase.js
@@ -8,7 +8,7 @@ const distributedLock = require("./shared/distributedLock");
 const EventQueueError = require("./EventQueueError");
 const { arrayToFlatMap } = require("./shared/common");
 const eventScheduler = require("./shared/eventScheduler");
-const eventQueueConfig = require("./config");
+const eventConfig = require("./config");
 const PerformanceTracer = require("./shared/PerformanceTracer");
 
 const IMPLEMENT_ERROR_MESSAGE = "needs to be reimplemented";
@@ -33,6 +33,7 @@ class EventQueueProcessorBase {
   #config = null;
   #eventSchedulerInstance = null;
   #eventConfig;
+  #isPeriodic;
 
   constructor(context, eventType, eventSubType, config) {
     this.__context = context;
@@ -40,11 +41,14 @@ class EventQueueProcessorBase {
     this.__tx = cds.tx(context);
     this.__baseLogger = cds.log(COMPONENT_NAME);
     this.#eventSchedulerInstance = eventScheduler.getInstance();
+    this.#config = eventConfig;
+    this.#isPeriodic = this.#config.isPeriodicEvent(eventType, eventSubType);
     this.__logger = null;
     this.__eventProcessingMap = {};
     this.__statusMap = {};
     this.__commitedStatusMap = {};
     this.#eventType = eventType;
+    // this.#eventType = `${eventType}${this.#isPeriodic ? SUFFIX_PERIODIC : ""}`;
     this.#eventSubType = eventSubType;
     this.#eventConfig = config ?? {};
     this.__parallelEventProcessing = this.#eventConfig.parallelEventProcessing ?? DEFAULT_PARALLEL_EVENT_PROCESSING;
@@ -74,7 +78,6 @@ class EventQueueProcessorBase {
     this.__txUsageAllowed = true;
     this.__txMap = {};
     this.__txRollback = {};
-    this.#config = eventQueueConfig.getConfigInstance();
     this.__queueEntries = [];
   }
 

--- a/src/EventQueueProcessorBase.js
+++ b/src/EventQueueProcessorBase.js
@@ -48,7 +48,6 @@ class EventQueueProcessorBase {
     this.__statusMap = {};
     this.__commitedStatusMap = {};
     this.#eventType = eventType;
-    // this.#eventType = `${eventType}${this.#isPeriodic ? SUFFIX_PERIODIC : ""}`;
     this.#eventSubType = eventSubType;
     this.#eventConfig = config ?? {};
     this.__parallelEventProcessing = this.#eventConfig.parallelEventProcessing ?? DEFAULT_PARALLEL_EVENT_PROCESSING;
@@ -875,6 +874,11 @@ class EventQueueProcessorBase {
       );
       // next tick is already behind schedule --> execute direct
       if (relativeAfterSchedule <= 0) {
+        this.logger.info("running behind schedule - executing next tick immediately", {
+          eventType: this.#eventType,
+          eventSubType: this.#eventSubType,
+          newStartAfter: newEvent.startAfter,
+        });
         return true;
       }
     }

--- a/src/dbHandler.js
+++ b/src/dbHandler.js
@@ -8,8 +8,7 @@ const config = require("./config");
 const COMPONENT_NAME = "eventQueue/dbHandler";
 
 const registerEventQueueDbHandler = (dbService) => {
-  const configInstance = config.getConfigInstance();
-  const def = dbService.model.definitions[configInstance.tableNameEventQueue];
+  const def = dbService.model.definitions[config.tableNameEventQueue];
   dbService.after("CREATE", def, (_, req) => {
     if (req.tx._skipEventQueueBroadcase) {
       return;
@@ -21,7 +20,7 @@ const registerEventQueueDbHandler = (dbService) => {
     const eventCombinations = Object.keys(
       data.reduce((result, event) => {
         const key = [event.type, event.subType].join("##");
-        if (!configInstance.hasEventAfterCommitFlag(event.type, event.subType) || eventQueuePublishEvents[key]) {
+        if (!config.hasEventAfterCommitFlag(event.type, event.subType) || eventQueuePublishEvents[key]) {
           return result;
         }
         eventQueuePublishEvents[key] = true;

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@
 
 module.exports = {
   ...require("./initialize"),
-  ...require("./config"),
+  config: require("./config"),
   ...require("./processEventQueue"),
   ...require("./dbHandler"),
   ...require("./constants"),

--- a/src/processEventQueue.js
+++ b/src/processEventQueue.js
@@ -4,7 +4,7 @@ const pathLib = require("path");
 
 const cds = require("@sap/cds");
 
-const { getConfigInstance } = require("./config");
+const config = require("./config");
 const { TransactionMode } = require("./constants");
 const { limiter, Funnel } = require("./shared/common");
 
@@ -29,7 +29,7 @@ const processEventQueue = async (context, eventType, eventSubType, startTime = n
   let baseInstance;
   try {
     let eventTypeInstance;
-    const eventConfig = getConfigInstance().getEventConfig(eventType, eventSubType);
+    const eventConfig = config.getEventConfig(eventType, eventSubType);
     const [err, EventTypeClass] = resilientRequire(eventConfig?.impl);
     if (!eventConfig || err || !(typeof EventTypeClass.constructor === "function")) {
       cds.log(COMPONENT_NAME).error("No Implementation found in the provided configuration file.", {

--- a/src/processEventQueue.js
+++ b/src/processEventQueue.js
@@ -137,58 +137,67 @@ const reevaluateShouldContinue = (eventTypeInstance, iterationCounter, startTime
 // TODO: don't forget to release lock
 const processPeriodicEvent = async (eventTypeInstance) => {
   let queueEntry;
+  let processNext = true;
+
   try {
-    await executeInNewTransaction(
-      eventTypeInstance.context,
-      `eventQueue-periodic-scheduleNext-${eventTypeInstance.eventType}##${eventTypeInstance.eventSubType}`,
-      async (tx) => {
-        eventTypeInstance.processEventContext = tx.context;
-        const queueEntries = await eventTypeInstance.getQueueEntriesAndSetToInProgress();
-        if (!queueEntries.length) {
-          return;
+    while (processNext) {
+      await executeInNewTransaction(
+        eventTypeInstance.context,
+        `eventQueue-periodic-scheduleNext-${eventTypeInstance.eventType}##${eventTypeInstance.eventSubType}`,
+        async (tx) => {
+          eventTypeInstance.processEventContext = tx.context;
+          const queueEntries = await eventTypeInstance.getQueueEntriesAndSetToInProgress();
+          if (!queueEntries.length) {
+            return;
+          }
+          if (queueEntries.length > 1) {
+            queueEntry = await eventTypeInstance.handleDuplicatedPeriodicEventEntry(queueEntries);
+          } else {
+            queueEntry = queueEntries[0];
+          }
+          processNext = await eventTypeInstance.scheduleNextPeriodEvent(queueEntry);
         }
-        if (queueEntries.length > 1) {
-          queueEntry = await eventTypeInstance.handleDuplicatedPeriodicEventEntry(queueEntries);
-        } else {
-          queueEntry = queueEntries[0];
-        }
-        await eventTypeInstance.scheduleNextPeriodEvent(queueEntry);
-      }
-    );
+      );
 
-    if (!queueEntry) {
-      return;
+      if (!queueEntry) {
+        return;
+      }
+
+      await executeInNewTransaction(
+        eventTypeInstance.context,
+        `eventQueue-periodic-process-${eventTypeInstance.eventType}##${eventTypeInstance.eventSubType}`,
+        async (tx) => {
+          eventTypeInstance.processEventContext = tx.context;
+          eventTypeInstance.setTxForEventProcessing(queueEntry.ID, cds.tx(tx.context));
+          try {
+            await eventTypeInstance.processEvent(tx.context, queueEntry.ID, [queueEntry]);
+          } catch (err) {
+            eventTypeInstance.handleErrorDuringPeriodicEventProcessing(err, queueEntry);
+            throw new TriggerRollback();
+          }
+          if (
+            eventTypeInstance.transactionMode !== TransactionMode.alwaysCommit ||
+            eventTypeInstance.shouldRollbackTransaction(queueEntry.ID)
+          ) {
+            throw new TriggerRollback();
+          }
+        }
+      );
+
+      await executeInNewTransaction(
+        eventTypeInstance.context,
+        `eventQueue-periodic-setStatus-${eventTypeInstance.eventType}##${eventTypeInstance.eventSubType}`,
+        async (tx) => {
+          eventTypeInstance.processEventContext = tx.context;
+          await eventTypeInstance.setPeriodicEventStatus(queueEntry.ID);
+        }
+      );
     }
-
-    await executeInNewTransaction(
-      eventTypeInstance.context,
-      `eventQueue-periodic-process-${eventTypeInstance.eventType}##${eventTypeInstance.eventSubType}`,
-      async (tx) => {
-        eventTypeInstance.processEventContext = tx.context;
-        eventTypeInstance.setTxForEventProcessing(queueEntry.ID, cds.tx(tx.context));
-        try {
-          await eventTypeInstance.processEvent(tx.context, queueEntry.ID, [queueEntry]);
-        } catch (err) {
-          eventTypeInstance.handleErrorDuringPeriodicEventProcessing(err, queueEntry);
-          throw new TriggerRollback();
-        }
-        if (
-          eventTypeInstance.transactionMode !== TransactionMode.alwaysCommit ||
-          eventTypeInstance.shouldRollbackTransaction(queueEntry.ID)
-        ) {
-          throw new TriggerRollback();
-        }
-      }
-    );
-
-    await executeInNewTransaction(
-      eventTypeInstance.context,
-      `eventQueue-periodic-setStatus-${eventTypeInstance.eventType}##${eventTypeInstance.eventSubType}`,
-      async (tx) => {
-        eventTypeInstance.processEventContext = tx.context;
-        await eventTypeInstance.setPeriodicEventStatus(queueEntry.ID);
-      }
-    );
+  } catch (err) {
+    cds.log(COMPONENT_NAME).error("Processing periodic events failed with unexpected error. Error:", err, {
+      eventType: eventTypeInstance?.eventType,
+      eventSubType: eventTypeInstance?.eventSubType,
+    });
   } finally {
     await eventTypeInstance?.handleReleaseLock();
   }

--- a/src/publishEvent.js
+++ b/src/publishEvent.js
@@ -28,13 +28,12 @@ const EventQueueError = require("./EventQueueError");
  * @returns {Promise} Returns a promise which resolves to the result of the database insert operation.
  */
 const publishEvent = async (tx, events, skipBroadcast = false) => {
-  const configInstance = config.getConfigInstance();
-  if (!configInstance.initialized) {
+  if (!config.initialized) {
     throw EventQueueError.notInitialized();
   }
   const eventsForProcessing = Array.isArray(events) ? events : [events];
   for (const { type, subType, startAfter } of eventsForProcessing) {
-    const eventConfig = configInstance.getEventConfig(type, subType);
+    const eventConfig = config.getEventConfig(type, subType);
     if (!eventConfig) {
       throw EventQueueError.unknownEventType(type, subType);
     }
@@ -47,7 +46,7 @@ const publishEvent = async (tx, events, skipBroadcast = false) => {
     }
   }
   tx._skipEventQueueBroadcase = skipBroadcast;
-  const result = await tx.run(INSERT.into(configInstance.tableNameEventQueue).entries(eventsForProcessing));
+  const result = await tx.run(INSERT.into(config.tableNameEventQueue).entries(eventsForProcessing));
   tx._skipEventQueueBroadcase = false;
   return result;
 };

--- a/src/redisPubSub.js
+++ b/src/redisPubSub.js
@@ -11,7 +11,7 @@ const COMPONENT_NAME = "eventQueue/redisPubSub";
 let subscriberClientPromise;
 
 const initEventQueueRedisSubscribe = () => {
-  if (subscriberClientPromise || !config.getConfigInstance().redisEnabled) {
+  if (subscriberClientPromise || !config.redisEnabled) {
     return;
   }
   redis.subscribeRedisChannel(EVENT_MESSAGE_CHANNEL, messageHandlerProcessEvents);
@@ -36,9 +36,8 @@ const messageHandlerProcessEvents = async (messageData) => {
 
 const broadcastEvent = async (tenantId, type, subType) => {
   const logger = cds.log(COMPONENT_NAME);
-  const configInstance = config.getConfigInstance();
-  if (!configInstance.redisEnabled) {
-    if (configInstance.registerAsEventProcessor) {
+  if (!config.redisEnabled) {
+    if (config.registerAsEventProcessor) {
       await runEventCombinationForTenant(tenantId, type, subType);
     }
     return;

--- a/src/shared/WorkerQueue.js
+++ b/src/shared/WorkerQueue.js
@@ -2,7 +2,7 @@
 
 const cds = require("@sap/cds");
 
-const { getConfigInstance } = require("../config");
+const config = require("../config");
 
 const COMPONENT_NAME = "eventQueue/WorkerQueue";
 
@@ -56,8 +56,7 @@ class WorkerQueue {
 module.exports = {
   getWorkerPoolInstance: () => {
     if (!instance) {
-      const configInstance = getConfigInstance();
-      instance = new WorkerQueue(configInstance.parallelTenantProcessing);
+      instance = new WorkerQueue(config.parallelTenantProcessing);
     }
     return instance;
   },

--- a/src/shared/cdsHelper.js
+++ b/src/shared/cdsHelper.js
@@ -94,7 +94,7 @@ class TriggerRollback extends VError {
 }
 
 const getSubdomainForTenantId = async (tenantId) => {
-  if (!config.getConfigInstance().isMultiTenancy) {
+  if (!config.isMultiTenancy) {
     return null;
   }
   if (subdomainCache[tenantId]) {
@@ -111,7 +111,7 @@ const getSubdomainForTenantId = async (tenantId) => {
 };
 
 const getAllTenantIds = async () => {
-  if (!config.getConfigInstance().isMultiTenancy) {
+  if (!config.isMultiTenancy) {
     return null;
   }
   const ssp = await cds.connect.to("cds.xt.SaasProvisioningService");

--- a/src/shared/eventScheduler.js
+++ b/src/shared/eventScheduler.js
@@ -38,9 +38,8 @@ class EventScheduler {
   }
 
   calculateOffset(type, subType, startAfter) {
-    const configInstance = config.getConfigInstance();
-    const eventConfig = configInstance.getEventConfig(type, subType);
-    const scheduleWithoutDelay = configInstance.isPeriodicEvent(type, subType) && eventConfig.interval < 30 * 1000;
+    const eventConfig = config.getEventConfig(type, subType);
+    const scheduleWithoutDelay = config.isPeriodicEvent(type, subType) && eventConfig.interval < 30 * 1000;
     const date = scheduleWithoutDelay ? startAfter : this.calculateFutureTime(startAfter, 10);
 
     return { date, relative: date.getTime() - Date.now() };

--- a/src/shared/eventScheduler.js
+++ b/src/shared/eventScheduler.js
@@ -13,11 +13,8 @@ class EventScheduler {
   constructor() {}
 
   scheduleEvent(tenantId, type, subType, startAfter) {
-    const configInstance = config.getConfigInstance();
-    const eventConfig = configInstance.getEventConfig(type, subType);
-    const scheduleWithoutDelay = configInstance.isPeriodicEvent(type, subType) && eventConfig.interval < 30 * 1000;
-    const roundUpDate = scheduleWithoutDelay ? startAfter : this.calculateFutureTime(startAfter, 10);
-    const key = [tenantId, type, subType, roundUpDate.toISOString()].join("##");
+    const { date, relative } = this.calculateOffset(type, subType, startAfter);
+    const key = [tenantId, type, subType, date.toISOString()].join("##");
     if (this.#scheduledEvents[key]) {
       return; // event combination already scheduled
     }
@@ -25,7 +22,7 @@ class EventScheduler {
     cds.log(COMPONENT_NAME).info("scheduling event queue run for delayed event", {
       type,
       subType,
-      delaySeconds: (roundUpDate.getTime() - Date.now()) / 1000,
+      delaySeconds: (date.getTime() - Date.now()) / 1000,
     });
     setTimeout(() => {
       delete this.#scheduledEvents[key];
@@ -34,10 +31,19 @@ class EventScheduler {
           tenantId,
           type,
           subType,
-          scheduledFor: roundUpDate.toISOString(),
+          scheduledFor: date.toISOString(),
         });
       });
-    }, roundUpDate.getTime() - Date.now()).unref();
+    }, relative).unref();
+  }
+
+  calculateOffset(type, subType, startAfter) {
+    const configInstance = config.getConfigInstance();
+    const eventConfig = configInstance.getEventConfig(type, subType);
+    const scheduleWithoutDelay = configInstance.isPeriodicEvent(type, subType) && eventConfig.interval < 30 * 1000;
+    const date = scheduleWithoutDelay ? startAfter : this.calculateFutureTime(startAfter, 10);
+
+    return { date, relative: date.getTime() - Date.now() };
   }
 
   calculateFutureTime(date, seoncds) {

--- a/test-integration/integration-main.test.js
+++ b/test-integration/integration-main.test.js
@@ -757,9 +757,9 @@ describe("integration-main", () => {
 
       expect(scheduleNextSpy).toHaveBeenCalledTimes(1);
       expect(loggerMock.callsLengths().error).toEqual(0);
-      expect(loggerMock.calls().info[3][0]).toMatchInlineSnapshot(
-        `"interval adjusted because shifted more than one interval"`
-      );
+      expect(
+        loggerMock.calls().info.find(([log]) => log === "interval adjusted because shifted more than one interval")
+      ).toBeTruthy();
       const events = await testHelper.selectEventQueueAndReturn(tx, 2);
       const [done, open] = events.sort((a, b) => new Date(a.startAfter) - new Date(b.startAfter));
       expect(done).toEqual({

--- a/test-integration/runner.test.js
+++ b/test-integration/runner.test.js
@@ -41,7 +41,7 @@ describe("redisRunner", () => {
       processEventsAfterPublish: false,
       registerAsEventProcessor: false,
     });
-    configInstance = eventQueue.getConfigInstance();
+    configInstance = eventQueue.config;
     configInstance.redisEnabled = true;
     jest.clearAllMocks();
   });

--- a/test/EventScheduler.test.js
+++ b/test/EventScheduler.test.js
@@ -3,7 +3,7 @@
 const cds = require("@sap/cds");
 
 const { getInstance: getEventSchedulerInstance } = require("../src/shared/eventScheduler");
-const { getConfigInstance } = require("../src/config");
+const config = require("../src/config");
 const { broadcastEvent } = require("../src/redisPubSub");
 
 jest.mock("@sap/cds", () => ({
@@ -32,11 +32,10 @@ describe("EventScheduler", () => {
 
   beforeAll(() => {
     eventScheduler = getEventSchedulerInstance();
-    const configInstance = getConfigInstance();
-    jest.spyOn(configInstance, "getEventConfig").mockReturnValue({
+    jest.spyOn(config, "getEventConfig").mockReturnValue({
       interval: 60,
     });
-    jest.spyOn(configInstance, "isPeriodicEvent").mockReturnValue(false);
+    jest.spyOn(config, "isPeriodicEvent").mockReturnValue(false);
     jest.useFakeTimers();
   });
 

--- a/test/__snapshots__/baseFunctionality.test.js.snap
+++ b/test/__snapshots__/baseFunctionality.test.js.snap
@@ -85,7 +85,7 @@ exports[`baseFunctionality periodic events two open events - not allowed 1`] = `
   "More than one open events for the same configuration which is not allowed!",
   {
     "eventSubType": "DB",
-    "eventType": "HealthCheck",
+    "eventType": "HealthCheck_PERIODIC",
   },
 ]
 `;

--- a/test/__snapshots__/checkAndInsertPeriodicEvents.test.js.snap
+++ b/test/__snapshots__/checkAndInsertPeriodicEvents.test.js.snap
@@ -9,7 +9,7 @@ exports[`baseFunctionality basic insert all new events 1`] = `
         {
           "interval": 30,
           "subType": "DB",
-          "type": "HealthCheck",
+          "type": "HealthCheck_PERIODIC",
         },
       ],
     },
@@ -36,7 +36,7 @@ exports[`baseFunctionality delta insert 1`] = `
         {
           "interval": 30,
           "subType": "DB",
-          "type": "HealthCheck",
+          "type": "HealthCheck_PERIODIC",
         },
       ],
     },
@@ -48,7 +48,7 @@ exports[`baseFunctionality delta insert 1`] = `
         {
           "interval": 30,
           "subType": "DB2",
-          "type": "HealthCheck",
+          "type": "HealthCheck_PERIODIC",
         },
       ],
     },
@@ -80,7 +80,7 @@ exports[`baseFunctionality interval changed 1`] = `
         {
           "interval": 30,
           "subType": "DB",
-          "type": "HealthCheck",
+          "type": "HealthCheck_PERIODIC",
         },
       ],
     },
@@ -91,7 +91,7 @@ exports[`baseFunctionality interval changed 1`] = `
       "changedEvents": [
         {
           "subType": "DB",
-          "type": "HealthCheck",
+          "type": "HealthCheck_PERIODIC",
         },
       ],
     },
@@ -103,7 +103,7 @@ exports[`baseFunctionality interval changed 1`] = `
         {
           "interval": 10,
           "subType": "DB",
-          "type": "HealthCheck",
+          "type": "HealthCheck_PERIODIC",
         },
       ],
     },

--- a/test/baseFunctionality.test.js
+++ b/test/baseFunctionality.test.js
@@ -63,14 +63,14 @@ describe("baseFunctionality", () => {
 
   describe("ad-hoc events", () => {
     test("empty queue - nothing to do", async () => {
-      const event = eventQueue.getConfigInstance().events[0];
+      const event = eventQueue.config.events[0];
       await eventQueue.processEventQueue(context, event.type, event.subType);
       expect(loggerMock.callsLengths().error).toEqual(0);
     });
 
     test("insert one entry and process", async () => {
       await testHelper.insertEventEntry(tx);
-      const event = eventQueue.getConfigInstance().events[0];
+      const event = eventQueue.config.events[0];
       await eventQueue.processEventQueue(context, event.type, event.subType);
       expect(loggerMock.callsLengths().error).toEqual(0);
       await testHelper.selectEventQueueAndExpectDone(tx);
@@ -78,7 +78,7 @@ describe("baseFunctionality", () => {
 
     test("insert one delayed entry - should not directly be processed", async () => {
       await testHelper.insertEventEntry(tx, { delayedSeconds: 15 });
-      const event = eventQueue.getConfigInstance().events[0];
+      const event = eventQueue.config.events[0];
       const eventSchedulerInstance = eventScheduler.getInstance();
       const eventSchedulerSpy = jest.spyOn(eventSchedulerInstance, "scheduleEvent").mockReturnValue();
       await eventQueue.processEventQueue(context, event.type, event.subType);
@@ -89,7 +89,7 @@ describe("baseFunctionality", () => {
 
     test("insert one delayed entry after runInterval", async () => {
       await testHelper.insertEventEntry(tx, { delayedSeconds: 500 });
-      const event = eventQueue.getConfigInstance().events[0];
+      const event = eventQueue.config.events[0];
       await eventQueue.processEventQueue(context, event.type, event.subType);
       expect(loggerMock.callsLengths().error).toEqual(0);
       await testHelper.selectEventQueueAndExpectOpen(tx);
@@ -97,7 +97,7 @@ describe("baseFunctionality", () => {
 
     test("insert one delayed entry in past - should be directly be processed", async () => {
       await testHelper.insertEventEntry(tx, { delayedSeconds: -100 });
-      const event = eventQueue.getConfigInstance().events[0];
+      const event = eventQueue.config.events[0];
       await eventQueue.processEventQueue(context, event.type, event.subType);
       expect(loggerMock.callsLengths().error).toEqual(0);
       await testHelper.selectEventQueueAndExpectDone(tx);
@@ -106,7 +106,7 @@ describe("baseFunctionality", () => {
     test("should do nothing if no lock is available", async () => {
       await testHelper.insertEventEntry(tx);
       jest.spyOn(eventQueue.EventQueueProcessorBase.prototype, "handleDistributedLock").mockResolvedValueOnce(false);
-      const event = eventQueue.getConfigInstance().events[0];
+      const event = eventQueue.config.events[0];
       await eventQueue.processEventQueue(context, event.type, event.subType);
       expect(loggerMock.callsLengths().error).toEqual(0);
       await testHelper.selectEventQueueAndExpectOpen(tx);
@@ -126,7 +126,7 @@ describe("baseFunctionality", () => {
         jest
           .spyOn(eventQueue.EventQueueProcessorBase.prototype, "handleDistributedLock")
           .mockRejectedValueOnce(new Error("lock require failed"));
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.processEventQueue(context, event.type, event.subType);
         expect(loggerMock.callsLengths().error).toEqual(1);
         expect(loggerMock.calls().error).toMatchSnapshot();
@@ -138,7 +138,7 @@ describe("baseFunctionality", () => {
         jest
           .spyOn(eventQueue.EventQueueProcessorBase.prototype, "getQueueEntriesAndSetToInProgress")
           .mockRejectedValueOnce(new Error("db error"));
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.processEventQueue(context, event.type, event.subType);
         expect(loggerMock.callsLengths().error).toEqual(1);
         expect(loggerMock.calls().error).toMatchSnapshot();
@@ -150,7 +150,7 @@ describe("baseFunctionality", () => {
         jest.spyOn(eventQueue.EventQueueProcessorBase.prototype, "modifyQueueEntry").mockImplementationOnce(() => {
           throw new Error("syntax error");
         });
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.processEventQueue(context, event.type, event.subType);
         expect(loggerMock.callsLengths().error).toEqual(1);
         expect(loggerMock.calls().error).toMatchSnapshot();
@@ -162,7 +162,7 @@ describe("baseFunctionality", () => {
         jest
           .spyOn(EventQueueTest.prototype, "checkEventAndGeneratePayload")
           .mockRejectedValueOnce(new Error("syntax error"));
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.processEventQueue(context, event.type, event.subType);
         expect(loggerMock.callsLengths().error).toEqual(1);
         expect(loggerMock.calls().error).toMatchSnapshot();
@@ -174,7 +174,7 @@ describe("baseFunctionality", () => {
         jest.spyOn(eventQueue.EventQueueProcessorBase.prototype, "clusterQueueEntries").mockImplementationOnce(() => {
           throw new Error("syntax error");
         });
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.processEventQueue(context, event.type, event.subType);
         expect(loggerMock.callsLengths().error).toEqual(1);
         expect(loggerMock.calls().error).toMatchSnapshot();
@@ -190,7 +190,7 @@ describe("baseFunctionality", () => {
             return queueEntry.payload;
           });
         await tx.run(INSERT.into("sap.eventqueue.Event").entries(eventQueueEntry));
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.processEventQueue(context, event.type, event.subType);
         expect(loggerMock.callsLengths().error).toEqual(0);
         await testHelper.selectEventQueueAndExpectDone(tx);
@@ -203,7 +203,7 @@ describe("baseFunctionality", () => {
           return null;
         });
         await tx.run(INSERT.into("sap.eventqueue.Event").entries(eventQueueEntry));
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.processEventQueue(context, event.type, event.subType);
         expect(loggerMock.callsLengths().error).toEqual(0);
         await testHelper.selectEventQueueAndExpectDone(tx);
@@ -216,7 +216,7 @@ describe("baseFunctionality", () => {
           return undefined;
         });
         await tx.run(INSERT.into("sap.eventqueue.Event").entries(eventQueueEntry));
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.processEventQueue(context, event.type, event.subType);
         expect(loggerMock.callsLengths().error).toEqual(1);
         await testHelper.selectEventQueueAndExpectError(tx);
@@ -225,7 +225,7 @@ describe("baseFunctionality", () => {
 
     describe("insert events", () => {
       test("straight forward", async () => {
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await eventQueue.publishEvent(tx, {
           type: event.type,
           subType: event.subType,
@@ -264,7 +264,7 @@ describe("baseFunctionality", () => {
       });
 
       test("not a proper date", async () => {
-        const event = eventQueue.getConfigInstance().events[0];
+        const event = eventQueue.config.events[0];
         await expect(
           eventQueue.publishEvent(tx, {
             type: event.type,
@@ -283,7 +283,7 @@ describe("baseFunctionality", () => {
 
   describe("periodic events", () => {
     test("straight forward", async () => {
-      const event = eventQueue.getConfigInstance().periodicEvents[0];
+      const event = eventQueue.config.periodicEvents[0];
       await checkAndInsertPeriodicEvents(context);
       await eventQueue.processEventQueue(context, event.type, event.subType);
       expect(loggerMock.callsLengths().error).toEqual(0);
@@ -302,7 +302,7 @@ describe("baseFunctionality", () => {
     });
 
     test("two open events - not allowed", async () => {
-      const event = eventQueue.getConfigInstance().periodicEvents[0];
+      const event = eventQueue.config.periodicEvents[0];
       await checkAndInsertPeriodicEvents(context);
       await tx.run(
         INSERT.into("sap.eventqueue.Event").entries({

--- a/test/helper.js
+++ b/test/helper.js
@@ -13,7 +13,7 @@ const _selectEventQueueAndExpect = async (tx, status, expectedLength = 1, attemp
 };
 
 const getEventEntry = () => {
-  const event = eventQueue.getConfigInstance().events[0];
+  const event = eventQueue.config.events[0];
   return {
     type: event.type,
     subType: event.subType,

--- a/test/redisPubSub.test.js
+++ b/test/redisPubSub.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const distributedLock = require("../src/shared/distributedLock");
+const config = require("../src/config");
 const checkLockExistsSpy = jest.spyOn(distributedLock, "checkLockExistsAndReturnValue");
 
 const project = __dirname + "/.."; // The project's root folder
@@ -43,7 +44,6 @@ describe("eventQueue Redis Events and DB Handlers", () => {
   let loggerMock;
   beforeAll(async () => {
     const configFilePath = path.join(__dirname, "asset", "config.yml");
-    const configInstance = eventQueue.getConfigInstance();
     jest.spyOn(cds, "log").mockImplementation((layer) => {
       return mockLogger(layer);
     });
@@ -51,7 +51,7 @@ describe("eventQueue Redis Events and DB Handlers", () => {
       configFilePath,
       processEventsAfterPublish: true,
     });
-    configInstance.redisEnabled = true;
+    config.redisEnabled = true;
     eventQueue.registerEventQueueDbHandler(cds.db);
     loggerMock = mockLogger();
   });


### PR DESCRIPTION
handle next:
- [x] variable to skip run if already running
- [x] periodic without tenant context (maybe do in next iteration)
- [x] add info to documentation
- [x] what is with load - rework complete load parameter for ad-hoc redis events and so on
- [x] allow duplicate usage if ad hoc and periodic
- [x] parameter to deactivate periodic event runner (for e.g. local use cases) 
- [x] how to handle longer downtime (deployment)
- [x] lock is still blocked if tick is overdue