### PR TITLE
cds.build.register may be undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - use less db connections with new locking mechanism
 
+### Fixed
+
+- cds.build.register may be undefined if @sap/cds-dk is is not installed locally or globally
+
+
 ## v1.4.6 - 2024-05-28
 
 ### Added

--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -5,6 +5,6 @@ const cds = require("@sap/cds");
 const eventQueue = require("./src");
 const COMPONENT_NAME = "/eventQueue/plugin";
 
-if (!cds.build.register && cds.env.eventQueue) {
+if (!cds.build?.register && cds.env.eventQueue) {
   module.exports = eventQueue.initialize().catch((err) => cds.log(COMPONENT_NAME).error(err));
 }


### PR DESCRIPTION
The deprecated cds.build stub has been deleted - see https://github.tools.sap/cap/cds/pull/4334