### PR TITLE
Better env resolve for redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v1.8.2 - 2025-01-XX
+
+### Added
+
+- allow to override more redis options e.g. to connect to a remote redis-instance via SSH tunnel
+
 ## v1.8.1 - 2024-12-27
 
 ### Added

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -52,7 +52,7 @@ Call the initialize function in your server.js. Check here the available setting
 
 ```js
 eventQueue.initialize({
-    configFilePath: "./srv/eventConfig.yml",
+  configFilePath: "./srv/eventConfig.yml",
 });
 ```
 
@@ -64,7 +64,7 @@ such as the configuration file path, event processing behavior, load balancing, 
 The table includes the parameter name, a description of its purpose, and the default value if not specified.
 
 | Name                                 | Description                                                                                                                                                                                                                                                                                                                                      | Default        | Can be changed at runtime |
-|:-------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------|:--------------------------|
+| :----------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------- | :------------------------ |
 | configFilePath                       | Path to the configuration file.                                                                                                                                                                                                                                                                                                                  | null           | no                        |
 | registerAsEventProcessor             | Whether or not to register as an event processor. If false, the app can publish events but doesn't process events.                                                                                                                                                                                                                               | true           | no                        |
 | processEventsAfterPublish            | Whether or not to process events immediately after publish. Events are distributed via Redis to all available app instances.                                                                                                                                                                                                                     | true           | no                        |
@@ -116,7 +116,7 @@ cds bind --exec -- node -e 'console.log(process.env.VCAP_SERVICES)'
 In the output, locate the Redis service-binding credentials. Among these, the `hostname` and `port` properties will be
 specified. For example:
 
-- Hostname: `master.rg-6e17d023-ab3d-4c90-97c5-80``ef8a68a964ca.vwvwdz.euc1.cache.amazonaws.com`
+- Hostname: ` master.rg-6e17d023-ab3d-4c90-97c5-80``ef8a68a964ca.vwvwdz.euc1.cache.amazonaws.com `
 - Port: `6380`
 
 The hostname and port pattern may vary depending on the data center.

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
       }
     },
     "requires": {
+      "eventqueue-redis-cache": {
+        "vcap": { "label": "redis-cache" }
+      },
       "event-queue": {
         "model": "@cap-js-community/event-queue"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js-community/event-queue",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "An event queue that enables secure transactional processing of asynchronous and periodic events, featuring instant event processing with Redis Pub/Sub and load distribution across all application instances.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     },
     "requires": {
       "eventqueue-redis-cache": {
-        "vcap": { "label": "redis-cache" }
+        "vcap": {
+          "label": "redis-cache"
+        }
       },
       "event-queue": {
         "model": "@cap-js-community/event-queue"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
       }
     },
     "requires": {
-      "eventqueue-redis-cache": {
+      "redis-eventQueue": {
         "vcap": {
           "label": "redis-cache"
         }

--- a/src/config.js
+++ b/src/config.js
@@ -113,7 +113,7 @@ class Config {
   }
 
   _checkRedisIsBound() {
-    return !!this.#env.redisCredentialsFromEnv;
+    return !!this.#env.redisCredentials;
   }
 
   shouldBeProcessedInThisApplication(type, subType) {

--- a/src/shared/env.js
+++ b/src/shared/env.js
@@ -18,7 +18,7 @@ class Env {
   }
 
   get redisCredentials() {
-    return cds.requires["eventqueue-redis-cache"].credentials;
+    return cds.requires["redis-eventQueue"].credentials;
   }
 
   get applicationName() {

--- a/src/shared/env.js
+++ b/src/shared/env.js
@@ -1,25 +1,24 @@
 "use strict";
 
+const cds = require("@sap/cds");
+
 let instance;
 
 class Env {
-  #vcapServices;
   #vcapApplication;
   #vcapApplicationInstance;
 
   constructor() {
     try {
-      this.#vcapServices = JSON.parse(process.env.VCAP_SERVICES);
       this.#vcapApplication = JSON.parse(process.env.VCAP_APPLICATION);
     } catch {
-      this.#vcapServices = {};
       this.#vcapApplication = {};
     }
     this.#vcapApplicationInstance = Number(process.env.CF_INSTANCE_INDEX);
   }
 
   get redisCredentialsFromEnv() {
-    return this.#vcapServices["redis-cache"]?.[0]?.credentials;
+    return cds.requires["eventqueue-redis-cache"].credentials;
   }
 
   get applicationName() {
@@ -28,14 +27,6 @@ class Env {
 
   get applicationInstance() {
     return this.#vcapApplicationInstance;
-  }
-
-  set vcapServices(value) {
-    this.#vcapServices = value;
-  }
-
-  get vcapServices() {
-    return this.#vcapServices;
   }
 
   set applicationInstance(value) {

--- a/src/shared/env.js
+++ b/src/shared/env.js
@@ -17,7 +17,7 @@ class Env {
     this.#vcapApplicationInstance = Number(process.env.CF_INSTANCE_INDEX);
   }
 
-  get redisCredentialsFromEnv() {
+  get redisCredentials() {
     return cds.requires["eventqueue-redis-cache"].credentials;
   }
 

--- a/src/shared/redis.js
+++ b/src/shared/redis.js
@@ -34,7 +34,7 @@ const _createClientBase = (redisOptions = {}) => {
     const socket = Object.assign(
       {
         host: credentials.hostname,
-        tls: credentials.tls,
+        tls: !!credentials.tls,
         port: credentials.port,
       },
       redisOptions.socket

--- a/src/shared/redis.js
+++ b/src/shared/redis.js
@@ -27,25 +27,25 @@ const createMainClientAndConnect = (options) => {
   return mainClientPromise;
 };
 
-const _createClientBase = (redisOptions) => {
+const _createClientBase = (redisOptions = {}) => {
   const env = getEnvInstance();
   try {
     const credentials = env.redisCredentials;
-    const options = Object.assign(
+    const socket = Object.assign(
       {
-        password: credentials.password,
-        socket: {
-          host: credentials.hostname,
-          tls: credentials.tls,
-          port: credentials.port,
-        },
+        host: credentials.hostname,
+        tls: credentials.tls,
+        port: credentials.port,
       },
-      redisOptions
+      redisOptions.socket
     );
+    const options = Object.assign({}, redisOptions, {
+      password: redisOptions.password ?? credentials.password,
+      socket,
+    });
     if (credentials.cluster_mode) {
       return redis.createCluster({
         rootNodes: [options],
-        // https://github.com/redis/node-redis/issues/1782
         defaults: options,
       });
     }

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -10,7 +10,6 @@ cds.test(project);
 
 const redisSub = require("../src/redis/redisSub");
 const eventQueue = require("../src");
-const { getEnvInstance } = require("../src/shared/env");
 const runner = require("../src/runner/runner");
 const config = require("../src/config");
 const redis = require("../src/shared/redis");

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -241,7 +241,7 @@ describe("initialize", () => {
 
     test("multi tenancy with redis", async () => {
       cds.requires.multitenancy = {};
-      cds.requires["eventqueue-redis-cache"].credentials = {
+      cds.requires["redis-eventQueue"].credentials = {
         hostname: "123",
       };
       const multiTenancyRedisSpy = jest.spyOn(runner, "multiTenancyRedis").mockResolvedValueOnce();
@@ -260,7 +260,7 @@ describe("initialize", () => {
     });
 
     test("single tenant with redis", async () => {
-      cds.requires["eventqueue-redis-cache"].credentials = {
+      cds.requires["redis-eventQueue"].credentials = {
         hostname: "123",
       };
       const singleTenantRedisSpy = jest.spyOn(runner, "singleTenantRedis").mockResolvedValueOnce();
@@ -280,7 +280,7 @@ describe("initialize", () => {
 
     test("multi tenancy with redis - option to disable redis", async () => {
       cds.requires.multitenancy = {};
-      cds.requires["eventqueue-redis-cache"].credentials = {
+      cds.requires["redis-eventQueue"].credentials = {
         hostname: "123",
       };
       const multiTenancyRedisSpy = jest.spyOn(runner, "multiTenancyRedis").mockResolvedValueOnce();

--- a/test/initialize.test.js
+++ b/test/initialize.test.js
@@ -242,9 +242,8 @@ describe("initialize", () => {
 
     test("multi tenancy with redis", async () => {
       cds.requires.multitenancy = {};
-      const env = getEnvInstance();
-      env.vcapServices = {
-        "redis-cache": [{ credentials: { hostname: "123" } }],
+      cds.requires["eventqueue-redis-cache"].credentials = {
+        hostname: "123",
       };
       const multiTenancyRedisSpy = jest.spyOn(runner, "multiTenancyRedis").mockResolvedValueOnce();
       jest.spyOn(redis, "connectionCheck").mockResolvedValueOnce(true);
@@ -262,9 +261,8 @@ describe("initialize", () => {
     });
 
     test("single tenant with redis", async () => {
-      const env = getEnvInstance();
-      env.vcapServices = {
-        "redis-cache": [{ credentials: { hostname: "123" } }],
+      cds.requires["eventqueue-redis-cache"].credentials = {
+        hostname: "123",
       };
       const singleTenantRedisSpy = jest.spyOn(runner, "singleTenantRedis").mockResolvedValueOnce();
       jest.spyOn(redis, "connectionCheck").mockResolvedValueOnce(true);
@@ -283,9 +281,8 @@ describe("initialize", () => {
 
     test("multi tenancy with redis - option to disable redis", async () => {
       cds.requires.multitenancy = {};
-      const env = getEnvInstance();
-      env.vcapServices = {
-        "redis-cache": [{ credentials: { hostname: "123" } }],
+      cds.requires["eventqueue-redis-cache"].credentials = {
+        hostname: "123",
       };
       const multiTenancyRedisSpy = jest.spyOn(runner, "multiTenancyRedis").mockResolvedValueOnce();
       await eventQueue.initialize({

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -6,7 +6,6 @@ const cds = require("@sap/cds");
 const project = __dirname + "/.."; // The project's root folder
 cds.test(project);
 
-const { getEnvInstance } = require("../src/shared/env");
 const redisEventQueue = require("../src/shared/redis");
 const { Logger: mockLogger } = require("./mocks/logger");
 const { initialize } = require("../src/initialize");

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -25,7 +25,7 @@ jest.mock("redis", () => {
 describe("redis layer", () => {
   let loggerMock;
   beforeAll(async () => {
-    cds.requires["eventqueue-redis-cache"].credentials = {
+    cds.requires["redis-eventQueue"].credentials = {
       uri: "123",
     };
     jest.spyOn(cds, "log").mockImplementation((layer) => {

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -26,9 +26,8 @@ jest.mock("redis", () => {
 describe("redis layer", () => {
   let loggerMock;
   beforeAll(async () => {
-    const env = getEnvInstance();
-    env.vcapServices = {
-      "redis-cache": [{ credentials: { uri: "123" } }],
+    cds.requires["eventqueue-redis-cache"].credentials = {
+      uri: "123",
     };
     jest.spyOn(cds, "log").mockImplementation((layer) => {
       return mockLogger(layer);

--- a/test/redis.test.js
+++ b/test/redis.test.js
@@ -47,7 +47,14 @@ describe("redis layer", () => {
     expect(client.connect).toHaveBeenCalledTimes(1);
     expect(client.on).toHaveBeenCalledTimes(2);
     expect(loggerMock.callsLengths().error).toEqual(0);
-    expect(connectSpy).toHaveBeenCalledWith({ url: "123" });
+    expect(connectSpy).toHaveBeenCalledWith({
+      password: undefined,
+      socket: {
+        host: undefined,
+        port: undefined,
+        tls: undefined,
+      },
+    });
   });
 
   test("should spread custom options to create client", async () => {
@@ -57,7 +64,15 @@ describe("redis layer", () => {
     expect(client.connect).toHaveBeenCalledTimes(1);
     expect(client.on).toHaveBeenCalledTimes(2);
     expect(loggerMock.callsLengths().error).toEqual(0);
-    expect(connectSpy).toHaveBeenCalledWith({ url: "123", pingInterval: 100 });
+    expect(connectSpy).toHaveBeenCalledWith({
+      pingInterval: 100,
+      password: undefined,
+      socket: {
+        host: undefined,
+        port: undefined,
+        tls: undefined,
+      },
+    });
   });
 
   test("should override default values", async () => {
@@ -67,6 +82,15 @@ describe("redis layer", () => {
     expect(client.connect).toHaveBeenCalledTimes(1);
     expect(client.on).toHaveBeenCalledTimes(2);
     expect(loggerMock.callsLengths().error).toEqual(0);
-    expect(connectSpy).toHaveBeenCalledWith({ url: "1234", pingInterval: 100 });
+    expect(connectSpy).toHaveBeenCalledWith({
+      url: "1234",
+      pingInterval: 100,
+      password: undefined,
+      socket: {
+        host: undefined,
+        port: undefined,
+        tls: undefined,
+      },
+    });
   });
 });


### PR DESCRIPTION
better resolving of btp service credentials, based on issue
fix: https://github.com/cap-js-community/event-queue/issues/264

@oklemenz2 what do you think? I personally like that approach more, because we simply rely on CAP to resolve the credentials. I think you could also get rid of `xssev` we you switch to the CAP approach

FYI: @rlindner81 maybe also interesting for you to get the redis credentials; to also support kyma 