### PR TITLE
fix: support cds.queued/unqueued for cds 9

### DIFF
--- a/src/initialize.js
+++ b/src/initialize.js
@@ -182,6 +182,14 @@ const monkeyPatchCAPOutbox = () => {
       get: () => eventQueueAsOutbox.unboxed,
       configurable: true,
     });
+    Object.defineProperty(cds, "queued", {
+      get: () => eventQueueAsOutbox.outboxed,
+      configurable: true,
+    });
+    Object.defineProperty(cds, "unqueued", {
+      get: () => eventQueueAsOutbox.unboxed,
+      configurable: true,
+    });
   }
 };
 


### PR DESCRIPTION
cds 9 introduces (and uses) `cds.queued`/`cds.unqueued` as an alias for `cds.outboxed`/`cds.unboxed`.