### PR TITLE
Fix regex, string match combination

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -196,9 +196,7 @@ class Config {
             result = config.value.test(this.#env.applicationName);
           } else {
             const shouldBeProcessedBasedOnAppName = appNameConfig[this.#env.applicationName];
-            if (!shouldBeProcessedBasedOnAppName) {
-              result = config.value === this.#env.applicationName;
-            }
+            result = !!shouldBeProcessedBasedOnAppName;
           }
           if (result) {
             break;


### PR DESCRIPTION
The test _it("mix - regex no match - string match", async () => {_ currently succeeds, as _/srv-backend.*/i_ will be successfully tested so that the string comparison will never be executed.
When adding the start of line indicator (^) to the regex the test will fail.