### PR TITLE
fix: derive retry startAfter from the recorded attempt timestamp

### DIFF
--- a/src/EventQueueProcessorBase.js
+++ b/src/EventQueueProcessorBase.js
@@ -457,7 +457,8 @@ class EventQueueProcessorBase {
         eventSubType: this.#eventSubType,
         statusMap,
       });
-      const ts = new Date().toISOString();
+      const tsMs = Date.now();
+      const ts = new Date(tsMs).toISOString();
       const updateData = Object.entries(statusMap).reduce((result, [id, data]) => {
         const key = this.allowedFieldsEventHandler
           .map((name) => [name, data[name]])
@@ -503,7 +504,7 @@ class EventQueueProcessorBase {
 
         if (!data.startAfter && [EventProcessingStatus.Error, EventProcessingStatus.Open].includes(data.status)) {
           data.startAfter = new Date(
-            Date.now() +
+            tsMs +
               (data.status === EventProcessingStatus.Error
                 ? this.#eventConfig.retryFailedAfter
                 : this.#eventConfig.retryOpenAfter)

--- a/test/eventQueueOutbox.test.js
+++ b/test/eventQueueOutbox.test.js
@@ -3176,10 +3176,8 @@ describe("event-queue outbox", () => {
         expect(event).toMatchObject({
           status: EventProcessingStatus.Error,
           attempts: 1,
+          startAfter: new Date(new Date(event.lastAttemptTimestamp).getTime() + 120 * 1000).toISOString(),
         });
-        const startAfterDelay = new Date(event.startAfter).getTime() - new Date(event.lastAttemptTimestamp).getTime();
-        expect(startAfterDelay).toBeGreaterThanOrEqual(120 * 1000 - 1000);
-        expect(startAfterDelay).toBeLessThanOrEqual(120 * 1000 + 1000);
         expect(loggerMock.callsLengths().error).toEqual(0);
       });
 
@@ -3195,10 +3193,8 @@ describe("event-queue outbox", () => {
         expect(event).toMatchObject({
           status: EventProcessingStatus.Open,
           attempts: 0,
+          startAfter: new Date(new Date(event.lastAttemptTimestamp).getTime() + 140 * 1000).toISOString(),
         });
-        const startAfterDelay = new Date(event.startAfter).getTime() - new Date(event.lastAttemptTimestamp).getTime();
-        expect(startAfterDelay).toBeGreaterThanOrEqual(140 * 1000 - 1000);
-        expect(startAfterDelay).toBeLessThanOrEqual(140 * 1000 + 1000);
         expect(loggerMock.callsLengths().error).toEqual(0);
       });
     });

--- a/test/eventQueueOutbox.test.js
+++ b/test/eventQueueOutbox.test.js
@@ -3176,8 +3176,10 @@ describe("event-queue outbox", () => {
         expect(event).toMatchObject({
           status: EventProcessingStatus.Error,
           attempts: 1,
-          startAfter: new Date(new Date(event.lastAttemptTimestamp).getTime() + 120 * 1000).toISOString(),
         });
+        const startAfterDelay = new Date(event.startAfter).getTime() - new Date(event.lastAttemptTimestamp).getTime();
+        expect(startAfterDelay).toBeGreaterThanOrEqual(120 * 1000 - 1000);
+        expect(startAfterDelay).toBeLessThanOrEqual(120 * 1000 + 1000);
         expect(loggerMock.callsLengths().error).toEqual(0);
       });
 
@@ -3193,8 +3195,10 @@ describe("event-queue outbox", () => {
         expect(event).toMatchObject({
           status: EventProcessingStatus.Open,
           attempts: 0,
-          startAfter: new Date(new Date(event.lastAttemptTimestamp).getTime() + 140 * 1000).toISOString(),
         });
+        const startAfterDelay = new Date(event.startAfter).getTime() - new Date(event.lastAttemptTimestamp).getTime();
+        expect(startAfterDelay).toBeGreaterThanOrEqual(140 * 1000 - 1000);
+        expect(startAfterDelay).toBeLessThanOrEqual(140 * 1000 + 1000);
         expect(loggerMock.callsLengths().error).toEqual(0);
       });
     });


### PR DESCRIPTION
## Summary
The `retry failed after` / `retry open after` outbox tests were flaky because they asserted `startAfter === lastAttemptTimestamp + retryDelay` exactly, e.g.:
```
- "startAfter": "2026-05-27T07:08:39.887Z",
+ "startAfter": "2026-05-27T07:08:39.888Z",
```

**Root cause (production):** in `EventQueueProcessorBase.persistEventStatus`, `lastAttemptTimestamp` was captured from one clock read (`new Date().toISOString()`) while the `startAfter` base used a *separate* `Date.now()` read taken later in the per-group loop. So `startAfter` was `Date.now() + delay`, not `lastAttemptTimestamp + delay` — the two drift ~1ms apart, which both caused the flake and made the retry delay slightly imprecise relative to the recorded attempt.

**Fix:** capture a single `Date.now()` (`tsMs`) and derive *both* `lastAttemptTimestamp` and `startAfter` from it. Now `startAfter == lastAttemptTimestamp + retryDelay` is an exact invariant. The retry-after tests keep their precise assertions (no tolerance needed).

Note: the first commit on this branch took the test-tolerance approach; the second commit replaces it with this production fix.

## Test plan
- [x] `npx jest test/eventQueueOutbox.test.js -t "retry open and failed after"` → 2 passed
- [x] `npx jest --selectProjects unit` → 364 passed
- [x] Prettier formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)